### PR TITLE
[PATCH] allow bwa to parse Casava 1.8 fastqs and filterer flagged

### DIFF
--- a/bwaseqio.c
+++ b/bwaseqio.c
@@ -157,6 +157,13 @@ bwa_seq_t *bwa_read_seq(bwa_seqio_t *bs, int n_needed, int *n, int mode, int tri
 	n_seqs = 0;
 	seqs = (bwa_seq_t*)calloc(n_needed, sizeof(bwa_seq_t));
 	while ((l = kseq_read(seq)) >= 0) {
+		if ((mode & BWA_MODE_CFY) && (seq->comment.l != 0)) {
+			// skip reads that are marked to be filtered by Casava
+			char *s = index(seq->comment.s, ':');
+			if (s && *(++s) == 'Y') {
+				continue;
+			}
+		}
 		if (is_64 && seq->qual.l)
 			for (i = 0; i < seq->qual.l; ++i) seq->qual.s[i] -= 31;
 		if (seq->seq.l <= l_bc) continue; // sequence length equals or smaller than the barcode length

--- a/bwtaln.c
+++ b/bwtaln.c
@@ -233,7 +233,7 @@ int bwa_aln(int argc, char *argv[])
 	gap_opt_t *opt;
 
 	opt = gap_init_opt();
-	while ((c = getopt(argc, argv, "n:o:e:i:d:l:k:cLR:m:t:NM:O:E:q:f:b012IB:")) >= 0) {
+	while ((c = getopt(argc, argv, "n:o:e:i:d:l:k:cLR:m:t:NM:O:E:q:f:b012IYB:")) >= 0) {
 		switch (c) {
 		case 'n':
 			if (strstr(optarg, ".")) opt->fnr = atof(optarg), opt->max_diff = -1;
@@ -261,6 +261,7 @@ int bwa_aln(int argc, char *argv[])
 		case '1': opt->mode |= BWA_MODE_BAM_READ1; break;
 		case '2': opt->mode |= BWA_MODE_BAM_READ2; break;
 		case 'I': opt->mode |= BWA_MODE_IL13; break;
+		case 'Y': opt->mode |= BWA_MODE_CFY; break;
 		case 'B': opt->mode |= atoi(optarg) << 24; break;
 		default: return 1;
 		}
@@ -298,6 +299,7 @@ int bwa_aln(int argc, char *argv[])
 		fprintf(stderr, "         -0        use single-end reads only (effective with -b)\n");
 		fprintf(stderr, "         -1        use the 1st read in a pair (effective with -b)\n");
 		fprintf(stderr, "         -2        use the 2nd read in a pair (effective with -b)\n");
+		fprintf(stderr, "         -Y        filter Casava-filtered sequences\n");
 		fprintf(stderr, "\n");
 		return 1;
 	}

--- a/bwtaln.h
+++ b/bwtaln.h
@@ -86,6 +86,7 @@ typedef struct {
 #define BWA_MODE_GAPE       0x01
 #define BWA_MODE_COMPREAD   0x02
 #define BWA_MODE_LOGGAP     0x04
+#define BWA_MODE_CFY        0x08
 #define BWA_MODE_NONSTOP    0x10
 #define BWA_MODE_BAM        0x20
 #define BWA_MODE_BAM_SE     0x40


### PR DESCRIPTION
In Casava 1.8 the fastq output changed, the name has a space which bwa
wasn't parsing correctly. This patch fixes it and enables bwa to filter
sequences marked :Y: by Casava. The tag is removed from the output.

Signed-off-by: RoelKluin roel.kluin@gmail.com
