### PR TITLE
read at the same address twice, a bug?

### DIFF
--- a/bwt.c
+++ b/bwt.c
@@ -142,7 +142,7 @@ inline void bwt_2occ(const bwt_t *bwt, bwtint_t k, bwtint_t l, ubyte_t c, bwtint
 		*ok = n;
 		// calculate *ol
 		j = l >> 5 << 5;
-		for (; i < j; i += 32, p += 2)
+		for (p += 2; i < j; i += 32, p += 2)
 			m += __occ_aux((uint64_t)p[0]<<32 | p[1], c);
 		m += __occ_aux(((uint64_t)p[0]<<32 | p[1]) & ~((1ull<<((~l&31)<<1)) - 1), c);
 		if (c == 0) m -= ~l&31; // corrected for the masked bits


### PR DESCRIPTION
## `I am not certain this is a bug, but please take a look at it, it looks suspicious to me. Is the read at the same address intentional?`

Without this increment of 'p' by 2, the same p[0] and p[1] are read twice,
once to increment 'n' (a few lines before the change, just after the previous
loop), and the second time in the first iteration of the loop this patch
changes.

Signed-off-by: Roel Kluin roel.kluin@gmail.com
