### PR TITLE
Mark QC-failing reads instead of skipping them

### DIFF
--- a/bwape.c
+++ b/bwape.c
@@ -720,10 +720,6 @@ void bwa_sai2sam_pe_core(const char *prefix, char *const fn_sa[2], char *const f
 		for (i = 0; i < n_seqs; ++i) {
 			bwa_seq_t *p[2];
 			p[0] = seqs[0] + i; p[1] = seqs[1] + i;
-			if (p[0]->bc[0] || p[1]->bc[0]) {
-				strcat(p[0]->bc, p[1]->bc);
-				strcpy(p[1]->bc, p[0]->bc);
-			}
 			bwa_print_sam1(bns, p[0], p[1], opt.mode, opt.max_top2);
 			bwa_print_sam1(bns, p[1], p[0], opt.mode, opt.max_top2);
 		}

--- a/bwtaln.h
+++ b/bwtaln.h
@@ -79,7 +79,7 @@ typedef struct {
 	// for multi-threading only
 	int tid;
 	// barcode
-	char bc[BWA_MAX_BCLEN+1]; // null terminated; up to BWA_MAX_BCLEN bases
+	char *bc; // store barcode, if any.
 	// NM and MD tags
 	uint32_t full_len:20, nm:12;
 	char *md;
@@ -98,7 +98,7 @@ typedef struct {
 
 typedef struct {
 	int s_mm, s_gapo, s_gape;
-	int mode; // bit 24-31 are the barcode length
+	uint32_t mode; // bit 24-31 are the barcode length
 	int indel_end_skip, max_del_occ, max_entries;
 	float fnr;
 	int max_diff, max_gapo, max_gape;


### PR DESCRIPTION
Modified QC behavior for bwa. Instead of skipping lines, just mark them as QC-failing.
I've noticed that bitwise flag for SAM output is only 8-bit long, whereas SAM specs say 10-bits.
I've shortened the len of seq in bwa_seq_t struct to 18 (should be sufficientg for many years to come) and increased extra_flag from 8 bits to 10 bits.
