### PR TITLE
xa2multi.pl: reverse sequence and phred if orientations differ between primary and secondary alignment

### DIFF
--- a/xa2multi.pl
+++ b/xa2multi.pl
@@ -10,7 +10,16 @@ while (<>) {
 		my @t = split("\t");
 		while ($l =~ /([^,;]+),([-+]\d+),([^,]+),(\d+);/g) {
 			my $mchr = ($t[6] eq $1)? '=' : $t[6]; # FIXME: TLEN/ISIZE is not calculated!
-			print(join("\t", $t[0], 0x100|($t[1]&0x6e9)|($2<0?0x10:0), $1, abs($2), 0, $3, @t[6..7], 0, @t[9..10], "NM:i:$4"), "\n");
+			my $seq = $t[9];
+			my $phred = $t[10];
+			# if alternative alignment has other orientation than primary, 
+			# then print the reverse (complement) of sequence and phred string
+			if ((($t[1]&0x10)>0) xor ($2<0)) {
+				$seq = reverse $seq;
+				$seq =~ tr/ACGTacgt/TGCAtgca/;
+				$phred = reverse $phred;
+			}
+			print(join("\t", $t[0], 0x100|($t[1]&0x6e9)|($2<0?0x10:0), $1, abs($2), 0, $3, @t[6..7], 0, $seq, $phred, "NM:i:$4"), "\n");
 		}
 	} else { print; }
 }


### PR DESCRIPTION
When a secondary alignment given in an XA tag differs in orientation from the primary one, the xa2multi.pl now gives the reverse complementary sequence and the reverse phred string.
