### PR TITLE
Small fix for possible compile problem on Ubuntu systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,10 @@ SUBDIRS=	.
 all:$(PROG)
 
 bwa:libbwa.a $(AOBJS) main.o
-		$(CC) $(CFLAGS) $(DFLAGS) $(AOBJS) main.o -o $@ $(LIBS) -L. -lbwa
+		$(CC) $(CFLAGS) $(DFLAGS) $(AOBJS) main.o -o $@ -L. -lbwa $(LIBS)
 
 bwamem-lite:libbwa.a example.o
-		$(CC) $(CFLAGS) $(DFLAGS) example.o -o $@ $(LIBS) -L. -lbwa
+		$(CC) $(CFLAGS) $(DFLAGS) example.o -o $@ -L. -lbwa $(LIBS)
 
 libbwa.a:$(LOBJS)
 		$(AR) -csru $@ $(LOBJS)


### PR DESCRIPTION
...n machine running 11.04, kernel 3.0.0-14-virtual).  Changing order of -lm on the command line seems to do the trick and should be tolerated in other environments.

The origin of the problem doesn't make complete sense to me, but it's been seen in the wild before, see i.e. http://stackoverflow.com/questions/7824439/c-math-linker-problems-on-ubuntu-11-10
