### PR TITLE
safe calls to stdlib malloc/realloc/strdup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.[oa]
 bwa
+bwamem-lite
 test
 test64
 .*.swp
+*~

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ CC=			gcc
 CFLAGS=		-g -Wall -O2
 AR=			ar
 DFLAGS=		-DHAVE_PTHREAD
-LOBJS=		utils.o kstring.o ksw.o bwt.o bntseq.o bwa.o bwamem.o bwamem_pair.o
+LOBJS=		utils.o kstring.o ksw.o bwt.o bntseq.o bwa.o bwamem.o bwamem_pair.o \
+		 memory.o
 AOBJS=		QSufSort.o bwt_gen.o bwase.o bwaseqio.o bwtgap.o bwtaln.o bamlite.o \
 			is.o bwtindex.o bwape.o kopen.o pemerge.o \
 			bwtsw2_core.o bwtsw2_main.o bwtsw2_aux.o bwt_lite.o \
@@ -11,6 +12,8 @@ PROG=		bwa
 INCLUDES=	
 LIBS=		-lm -lz -lpthread
 SUBDIRS=	.
+
+.PHONY: all clean
 
 .SUFFIXES:.c .o .cc
 
@@ -48,6 +51,7 @@ bwtgap.o:bwtgap.h bwtaln.h bwt.h
 bwtsw2_core.o:bwtsw2.h bwt.h bwt_lite.h
 bwtsw2_aux.o:bwtsw2.h bwt.h bwt_lite.h
 bwtsw2_main.o:bwtsw2.h
+memory.o: memory.h
 
 clean:
 		rm -f gmon.out *.o a.out $(PROG) *~ *.a

--- a/bamlite.c
+++ b/bamlite.c
@@ -2,6 +2,7 @@
 #include <ctype.h>
 #include <string.h>
 #include <stdio.h>
+#include "memory.h"
 #include "bamlite.h"
 
 /*********************
@@ -53,7 +54,7 @@ int bam_is_be;
 bam_header_t *bam_header_init()
 {
 	bam_is_be = bam_is_big_endian();
-	return (bam_header_t*)calloc(1, sizeof(bam_header_t));
+	return (bam_header_t*)SAFE_CALLOC(1, sizeof(bam_header_t));
 }
 
 void bam_header_destroy(bam_header_t *header)
@@ -86,17 +87,17 @@ bam_header_t *bam_header_read(bamFile fp)
 	// read plain text and the number of reference sequences
 	bam_read(fp, &header->l_text, 4);
 	if (bam_is_be) bam_swap_endian_4p(&header->l_text);
-	header->text = (char*)calloc(header->l_text + 1, 1);
+	header->text = (char*)SAFE_CALLOC(header->l_text + 1, 1);
 	bam_read(fp, header->text, header->l_text);
 	bam_read(fp, &header->n_targets, 4);
 	if (bam_is_be) bam_swap_endian_4p(&header->n_targets);
 	// read reference sequence names and lengths
-	header->target_name = (char**)calloc(header->n_targets, sizeof(char*));
-	header->target_len = (uint32_t*)calloc(header->n_targets, 4);
+	header->target_name = (char**)SAFE_CALLOC(header->n_targets, sizeof(char*));
+	header->target_len = (uint32_t*)SAFE_CALLOC(header->n_targets, 4);
 	for (i = 0; i != header->n_targets; ++i) {
 		bam_read(fp, &name_len, 4);
 		if (bam_is_be) bam_swap_endian_4p(&name_len);
-		header->target_name[i] = (char*)calloc(name_len, 1);
+		header->target_name[i] = (char*)SAFE_CALLOC(name_len, 1);
 		bam_read(fp, header->target_name[i], name_len);
 		bam_read(fp, &header->target_len[i], 4);
 		if (bam_is_be) bam_swap_endian_4p(&header->target_len[i]);
@@ -146,7 +147,7 @@ int bam_read1(bamFile fp, bam1_t *b)
 	if (b->m_data < b->data_len) {
 		b->m_data = b->data_len;
 		kroundup32(b->m_data);
-		b->data = (uint8_t*)realloc(b->data, b->m_data);
+		b->data = (uint8_t*)SAFE_REALLOC(b->data, b->m_data);
 	}
 	if (bam_read(fp, b->data, b->data_len) != b->data_len) return -4;
 	b->l_aux = b->data_len - c->n_cigar * 4 - c->l_qname - c->l_qseq - (c->l_qseq+1)/2;

--- a/bamlite.h
+++ b/bamlite.h
@@ -71,7 +71,7 @@ typedef struct {
 #define bam1_seqi(s, i) ((s)[(i)/2] >> 4*(1-(i)%2) & 0xf)
 #define bam1_aux(b) ((b)->data + (b)->core.n_cigar*4 + (b)->core.l_qname + (b)->core.l_qseq + ((b)->core.l_qseq + 1)/2)
 
-#define bam_init1() ((bam1_t*)calloc(1, sizeof(bam1_t)))
+#define bam_init1() ((bam1_t*)SAFE_CALLOC(1, sizeof(bam1_t)))
 #define bam_destroy1(b) do {					\
 		if (b) { free((b)->data); free(b); }	\
 	} while (0)

--- a/bwamem_pair.c
+++ b/bwamem_pair.c
@@ -2,6 +2,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <math.h>
+#include "memory.h"
 #include "kstring.h"
 #include "bwamem.h"
 #include "kvec.h"
@@ -121,7 +122,7 @@ int mem_matesw(const mem_opt_t *opt, int64_t l_pac, const uint8_t *pac, const me
 		is_rev = (r>>1 != (r&1)); // whether to reverse complement the mate
 		is_larger = !(r>>1); // whether the mate has larger coordinate
 		if (is_rev) {
-			rev = malloc(l_ms); // this is the reverse complement of $ms
+			rev = (uint8_t*)SAFE_MALLOC(l_ms); // this is the reverse complement of $ms
 			for (i = 0; i < l_ms; ++i) rev[l_ms - 1 - i] = ms[i] < 4? 3 - ms[i] : 4;
 			seq = rev;
 		} else seq = (uint8_t*)ms;
@@ -294,7 +295,7 @@ int mem_sam_pe(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac, co
 		// write SAM
 		h[0] = mem_reg2aln(opt, bns, pac, s[0].l_seq, s[0].seq, &a[0].a[z[0]]); h[0].mapq = q_se[0]; h[0].flag |= 0x40 | extra_flag;
 		h[1] = mem_reg2aln(opt, bns, pac, s[1].l_seq, s[1].seq, &a[1].a[z[1]]); h[1].mapq = q_se[1]; h[1].flag |= 0x80 | extra_flag;
-		mem_aln2sam(bns, &str, &s[0], 1, &h[0], 0, &h[1]); s[0].sam = strdup(str.s); str.l = 0;
+		mem_aln2sam(bns, &str, &s[0], 1, &h[0], 0, &h[1]); s[0].sam = SAFE_STRDUP(str.s); str.l = 0;
 		mem_aln2sam(bns, &str, &s[1], 1, &h[1], 0, &h[0]); s[1].sam = str.s;
 		free(h[0].cigar); free(h[1].cigar);
 	} else goto no_pairing;

--- a/bwape.c
+++ b/bwape.c
@@ -4,6 +4,7 @@
 #include <time.h>
 #include <stdio.h>
 #include <string.h>
+#include "memory.h"
 #include "bwtaln.h"
 #include "kvec.h"
 #include "bntseq.h"
@@ -50,7 +51,7 @@ void bwa_print_sam_PG();
 pe_opt_t *bwa_init_pe_opt()
 {
 	pe_opt_t *po;
-	po = (pe_opt_t*)calloc(1, sizeof(pe_opt_t));
+	po = (pe_opt_t*)SAFE_CALLOC(1, sizeof(pe_opt_t));
 	po->max_isize = 500;
 	po->force_isize = 0;
 	po->max_occ = 100000;
@@ -83,7 +84,7 @@ static int infer_isize(int n_seqs, bwa_seq_t *seqs[2], isize_info_t *ii, double 
 
 	ii->avg = ii->std = -1.0;
 	ii->low = ii->high = ii->high_bayesian = 0;
-	isizes = (uint64_t*)calloc(n_seqs, 8);
+	isizes = (uint64_t*)SAFE_CALLOC(n_seqs, 8);
 	for (i = 0, tot = 0; i != n_seqs; ++i) {
 		bwa_seq_t *p[2];
 		p[0] = seqs[0] + i; p[1] = seqs[1] + i;
@@ -263,9 +264,9 @@ int bwa_cal_pac_pos_pe(const bntseq_t *bns, const char *prefix, bwt_t *const _bw
 	pe_data_t *d;
 	aln_buf_t *buf[2];
 
-	d = (pe_data_t*)calloc(1, sizeof(pe_data_t));
-	buf[0] = (aln_buf_t*)calloc(n_seqs, sizeof(aln_buf_t));
-	buf[1] = (aln_buf_t*)calloc(n_seqs, sizeof(aln_buf_t));
+	d = (pe_data_t*)SAFE_CALLOC(1, sizeof(pe_data_t));
+	buf[0] = (aln_buf_t*)SAFE_CALLOC(n_seqs, sizeof(aln_buf_t));
+	buf[1] = (aln_buf_t*)SAFE_CALLOC(n_seqs, sizeof(aln_buf_t));
 
 	if (_bwt == 0) { // load forward SA
 		strcpy(str, prefix); strcat(str, ".bwt");  bwt = bwt_restore_bwt(str);
@@ -338,7 +339,7 @@ int bwa_cal_pac_pos_pe(const bntseq_t *bns, const char *prefix, bwt_t *const _bw
 						if (ret) { // not in the hash table; ret must equal 1 as we never remove elements
 							poslist_t *z = &kh_val(g_hash, iter);
 							z->n = r->l - r->k + 1;
-							z->a = (bwtint_t*)malloc(sizeof(bwtint_t) * z->n);
+							z->a = (bwtint_t*)SAFE_MALLOC(sizeof(bwtint_t) * z->n);
 							for (l = r->k; l <= r->l; ++l) {
 								int strand;
 								z->a[l - r->k] = bwa_sa2pos(bns, bwt, l, p[j]->len, &strand)<<1;
@@ -420,7 +421,7 @@ bwa_cigar_t *bwa_sw_core(bwtint_t l_pac, const ubyte_t *pacseq, int len, const u
 	if ((float)x/len >= 0.25 || len - x < SW_MIN_MATCH_LEN) return 0;
 
 	// get reference subsequence
-	ref_seq = (ubyte_t*)calloc(reglen, 1);
+	ref_seq = (ubyte_t*)SAFE_CALLOC(reglen, 1);
 	for (k = *beg, l = 0; l < reglen && k < l_pac; ++k)
 		ref_seq[l++] = pacseq[k>>2] >> ((~k&3)<<1) & 3;
 
@@ -453,7 +454,7 @@ bwa_cigar_t *bwa_sw_core(bwtint_t l_pac, const ubyte_t *pacseq, int len, const u
 	{ // update cigar and coordinate;
 		int start = r.qb, end = r.qe + 1;
 		*beg += r.tb;
-		cigar = (bwa_cigar_t*)realloc(cigar, sizeof(bwa_cigar_t) * (*n_cigar + 2));
+		cigar = (bwa_cigar_t*)SAFE_REALLOC(cigar, sizeof(bwa_cigar_t) * (*n_cigar + 2));
 		if (start) {
 			memmove(cigar + 1, cigar, sizeof(bwa_cigar_t) * (*n_cigar));
 			cigar[0] = __cigar_create(3, start);
@@ -497,7 +498,7 @@ ubyte_t *bwa_paired_sw(const bntseq_t *bns, const ubyte_t *_pacseq, int n_seqs, 
 
 	// load reference sequence
 	if (_pacseq == 0) {
-		pacseq = (ubyte_t*)calloc(bns->l_pac/4+1, 1);
+		pacseq = (ubyte_t*)SAFE_CALLOC(bns->l_pac/4+1, 1);
 		rewind(bns->fp_pac);
 		fread(pacseq, 1, bns->l_pac/4+1, bns->fp_pac);
 	} else pacseq = (ubyte_t*)_pacseq;
@@ -653,7 +654,7 @@ void bwa_sai2sam_pe_core(const char *prefix, char *const fn_sa[2], char *const f
 		if (popt->is_preload) {
 			strcpy(str, prefix); strcat(str, ".bwt");  bwt = bwt_restore_bwt(str);
 			strcpy(str, prefix); strcat(str, ".sa"); bwt_restore_sa(str, bwt);
-			pac = (ubyte_t*)calloc(bns->l_pac/4+1, 1);
+			pac = (ubyte_t*)SAFE_CALLOC(bns->l_pac/4+1, 1);
 			rewind(bns->fp_pac);
 			fread(pac, 1, bns->l_pac/4+1, bns->fp_pac);
 		}

--- a/bwaseqio.c
+++ b/bwaseqio.c
@@ -1,9 +1,9 @@
 #include <zlib.h>
 #include <ctype.h>
+#include "memory.h"
 #include "bwtaln.h"
 #include "utils.h"
 #include "bamlite.h"
-
 #include "kseq.h"
 KSEQ_DECLARE(gzFile)
 
@@ -22,7 +22,7 @@ bwa_seqio_t *bwa_bam_open(const char *fn, int which)
 {
 	bwa_seqio_t *bs;
 	bam_header_t *h;
-	bs = (bwa_seqio_t*)calloc(1, sizeof(bwa_seqio_t));
+	bs = (bwa_seqio_t*)SAFE_CALLOC(1, sizeof(bwa_seqio_t));
 	bs->is_bam = 1;
 	bs->which = which;
 	bs->fp = bam_open(fn, "r");
@@ -35,7 +35,7 @@ bwa_seqio_t *bwa_seq_open(const char *fn)
 {
 	gzFile fp;
 	bwa_seqio_t *bs;
-	bs = (bwa_seqio_t*)calloc(1, sizeof(bwa_seqio_t));
+	bs = (bwa_seqio_t*)SAFE_CALLOC(1, sizeof(bwa_seqio_t));
 	fp = xzopen(fn, "r");
 	bs->ks = kseq_init(fp);
 	return bs;
@@ -93,7 +93,7 @@ static bwa_seq_t *bwa_read_bam(bwa_seqio_t *bs, int n_needed, int *n, int is_com
 
 	b = bam_init1();
 	n_seqs = 0;
-	seqs = (bwa_seq_t*)calloc(n_needed, sizeof(bwa_seq_t));
+	seqs = (bwa_seq_t*)SAFE_CALLOC(n_needed, sizeof(bwa_seq_t));
 	while (bam_read1(bs->fp, b) >= 0) {
 		uint8_t *s, *q;
 		int go = 0;
@@ -108,8 +108,8 @@ static bwa_seq_t *bwa_read_bam(bwa_seqio_t *bs, int n_needed, int *n, int is_com
 		p->full_len = p->clip_len = p->len = l;
 		n_tot += p->full_len;
 		s = bam1_seq(b); q = bam1_qual(b);
-		p->seq = (ubyte_t*)calloc(p->len + 1, 1);
-		p->qual = (ubyte_t*)calloc(p->len + 1, 1);
+		p->seq = (ubyte_t*)SAFE_CALLOC(p->len + 1, 1);
+		p->qual = (ubyte_t*)SAFE_CALLOC(p->len + 1, 1);
 		for (i = 0; i != p->full_len; ++i) {
 			p->seq[i] = bam_nt16_nt4_table[(int)bam1_seqi(s, i)];
 			p->qual[i] = q[i] + 33 < 126? q[i] + 33 : 126;
@@ -119,11 +119,11 @@ static bwa_seq_t *bwa_read_bam(bwa_seqio_t *bs, int n_needed, int *n, int is_com
 			seq_reverse(p->len, p->qual, 0);
 		}
 		if (trim_qual >= 1) n_trimmed += bwa_trim_read(trim_qual, p);
-		p->rseq = (ubyte_t*)calloc(p->full_len, 1);
+		p->rseq = (ubyte_t*)SAFE_CALLOC(p->full_len, 1);
 		memcpy(p->rseq, p->seq, p->len);
 		seq_reverse(p->len, p->seq, 0); // *IMPORTANT*: will be reversed back in bwa_refine_gapped()
 		seq_reverse(p->len, p->rseq, is_comp);
-		p->name = strdup((const char*)bam1_qname(b));
+		p->name = SAFE_STRDUP((const char*)bam1_qname(b));
 		if (n_seqs == n_needed) break;
 	}
 	*n = n_seqs;
@@ -153,7 +153,7 @@ bwa_seq_t *bwa_read_seq(bwa_seqio_t *bs, int n_needed, int *n, int mode, int tri
 	}
 	if (bs->is_bam) return bwa_read_bam(bs, n_needed, n, is_comp, trim_qual); // l_bc has no effect for BAM input
 	n_seqs = 0;
-	seqs = (bwa_seq_t*)calloc(n_needed, sizeof(bwa_seq_t));
+	seqs = (bwa_seq_t*)SAFE_CALLOC(n_needed, sizeof(bwa_seq_t));
 	while ((l = kseq_read(seq)) >= 0) {
 		if ((mode & BWA_MODE_CFY) && (seq->comment.l != 0)) {
 			// skip reads that are marked to be filtered by Casava
@@ -184,18 +184,18 @@ bwa_seq_t *bwa_read_seq(bwa_seqio_t *bs, int n_needed, int *n, int mode, int tri
 		p->qual = 0;
 		p->full_len = p->clip_len = p->len = l;
 		n_tot += p->full_len;
-		p->seq = (ubyte_t*)calloc(p->len, 1);
+		p->seq = (ubyte_t*)SAFE_CALLOC(p->len, 1);
 		for (i = 0; i != p->full_len; ++i)
 			p->seq[i] = nst_nt4_table[(int)seq->seq.s[i]];
 		if (seq->qual.l) { // copy quality
-			p->qual = (ubyte_t*)strdup((char*)seq->qual.s);
+			p->qual = (ubyte_t*)SAFE_STRDUP((char*)seq->qual.s);
 			if (trim_qual >= 1) n_trimmed += bwa_trim_read(trim_qual, p);
 		}
-		p->rseq = (ubyte_t*)calloc(p->full_len, 1);
+		p->rseq = (ubyte_t*)SAFE_CALLOC(p->full_len, 1);
 		memcpy(p->rseq, p->seq, p->len);
 		seq_reverse(p->len, p->seq, 0); // *IMPORTANT*: will be reversed back in bwa_refine_gapped()
 		seq_reverse(p->len, p->rseq, is_comp);
-		p->name = strdup((const char*)seq->name.s);
+		p->name = SAFE_STRDUP((const char*)seq->name.s);
 		{ // trim /[12]$
 			int t = strlen(p->name);
 			if (t > 2 && p->name[t-2] == '/' && (p->name[t-1] == '1' || p->name[t-1] == '2')) p->name[t-2] = '\0';

--- a/bwt.c
+++ b/bwt.c
@@ -30,6 +30,7 @@
 #include <string.h>
 #include <assert.h>
 #include <stdint.h>
+#include "memory.h"
 #include "utils.h"
 #include "bwt.h"
 #include "kvec.h"
@@ -66,7 +67,7 @@ void bwt_cal_sa(bwt_t *bwt, int intv)
 	if (bwt->sa) free(bwt->sa);
 	bwt->sa_intv = intv;
 	bwt->n_sa = (bwt->seq_len + intv) / intv;
-	bwt->sa = (bwtint_t*)calloc(bwt->n_sa, sizeof(bwtint_t));
+	bwt->sa = (bwtint_t*)SAFE_CALLOC(bwt->n_sa, sizeof(bwtint_t));
 	if (bwt->sa == 0) {
 		fprintf(stderr, "[%s] Fail to allocate %.3fMB memory. Abort!\n", __func__, bwt->n_sa * sizeof(bwtint_t) / 1024.0/1024.0);
 		abort();
@@ -399,7 +400,7 @@ void bwt_restore_sa(const char *fn, bwt_t *bwt)
 	xassert(primary == bwt->seq_len, "SA-BWT inconsistency: seq_len is not the same.");
 
 	bwt->n_sa = (bwt->seq_len + bwt->sa_intv) / bwt->sa_intv;
-	bwt->sa = (bwtint_t*)calloc(bwt->n_sa, sizeof(bwtint_t));
+	bwt->sa = (bwtint_t*)SAFE_CALLOC(bwt->n_sa, sizeof(bwtint_t));
 	bwt->sa[0] = -1;
 
 	fread_fix(fp, sizeof(bwtint_t) * (bwt->n_sa - 1), bwt->sa + 1);
@@ -411,11 +412,11 @@ bwt_t *bwt_restore_bwt(const char *fn)
 	bwt_t *bwt;
 	FILE *fp;
 
-	bwt = (bwt_t*)calloc(1, sizeof(bwt_t));
+	bwt = (bwt_t*)SAFE_CALLOC(1, sizeof(bwt_t));
 	fp = xopen(fn, "rb");
 	fseek(fp, 0, SEEK_END);
 	bwt->bwt_size = (ftell(fp) - sizeof(bwtint_t) * 5) >> 2;
-	bwt->bwt = (uint32_t*)calloc(bwt->bwt_size, 4);
+	bwt->bwt = (uint32_t*)SAFE_CALLOC(bwt->bwt_size, 4);
 	fseek(fp, 0, SEEK_SET);
 	fread(&bwt->primary, sizeof(bwtint_t), 1, fp);
 	fread(bwt->L2+1, sizeof(bwtint_t), 4, fp);

--- a/bwt.h
+++ b/bwt.h
@@ -31,6 +31,8 @@
 #include <stdint.h>
 #include <stddef.h>
 
+
+
 // requirement: (OCC_INTERVAL%16 == 0); please DO NOT change this line because some part of the code assume OCC_INTERVAL=0x80
 #define OCC_INTV_SHIFT 7
 #define OCC_INTERVAL   (1LL<<OCC_INTV_SHIFT)

--- a/bwt_lite.c
+++ b/bwt_lite.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include "memory.h"
 #include "bwt_lite.h"
 
 int is_sa(const uint8_t *T, uint32_t *SA, int n);
@@ -10,21 +11,21 @@ bwtl_t *bwtl_seq2bwtl(int len, const uint8_t *seq)
 {
 	bwtl_t *b;
 	int i;
-	b = (bwtl_t*)calloc(1, sizeof(bwtl_t));
+	b = (bwtl_t*)SAFE_CALLOC(1, sizeof(bwtl_t));
 	b->seq_len = len;
 
 	{ // calculate b->bwt
 		uint8_t *s;
-		b->sa = (uint32_t*)calloc(len + 1, 4);
+		b->sa = (uint32_t*)SAFE_CALLOC(len + 1, 4);
 		is_sa(seq, b->sa, len);
-		s = (uint8_t*)calloc(len + 1, 1);
+		s = (uint8_t*)SAFE_CALLOC(len + 1, 1);
 		for (i = 0; i <= len; ++i) {
 			if (b->sa[i] == 0) b->primary = i;
 			else s[i] = seq[b->sa[i] - 1];
 		}
 		for (i = b->primary; i < len; ++i) s[i] = s[i + 1];
 		b->bwt_size = (len + 15) / 16;
-		b->bwt = (uint32_t*)calloc(b->bwt_size, 4);
+		b->bwt = (uint32_t*)SAFE_CALLOC(b->bwt_size, 4);
 		for (i = 0; i < len; ++i)
 			b->bwt[i>>4] |= s[i] << ((15 - (i&15)) << 1);
 		free(s);
@@ -32,7 +33,7 @@ bwtl_t *bwtl_seq2bwtl(int len, const uint8_t *seq)
 	{ // calculate b->occ
 		uint32_t c[4];
 		b->n_occ = (len + 15) / 16 * 4;
-		b->occ = (uint32_t*)calloc(b->n_occ, 4);
+		b->occ = (uint32_t*)SAFE_CALLOC(b->n_occ, 4);
 		memset(c, 0, 16);
 		for (i = 0; i < len; ++i) {
 			if (i % 16 == 0)

--- a/bwtaln.c
+++ b/bwtaln.c
@@ -8,6 +8,7 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
+#include "memory.h"
 #include "bwtaln.h"
 #include "bwtgap.h"
 #include "utils.h"
@@ -20,7 +21,7 @@
 gap_opt_t *gap_init_opt()
 {
 	gap_opt_t *o;
-	o = (gap_opt_t*)calloc(1, sizeof(gap_opt_t));
+	o = (gap_opt_t*)SAFE_CALLOC(1, sizeof(gap_opt_t));
 	/* IMPORTANT: s_mm*10 should be about the average base error
 	   rate. Voilating this requirement will break pairing! */
 	o->s_mm = 3; o->s_gapo = 11; o->s_gape = 4;
@@ -90,7 +91,7 @@ void bwa_cal_sa_reg_gap(int tid, bwt_t *const bwt, int n_seqs, bwa_seq_t *seqs, 
 	if (local_opt.max_diff < local_opt.max_gapo) local_opt.max_gapo = local_opt.max_diff;
 	stack = gap_init_stack(local_opt.max_diff, local_opt.max_gapo, local_opt.max_gape, &local_opt);
 
-	seed_w = (bwt_width_t*)calloc(opt->seed_len+1, sizeof(bwt_width_t));
+	seed_w = (bwt_width_t*)SAFE_CALLOC(opt->seed_len+1, sizeof(bwt_width_t));
 	w = 0;
 	for (i = 0; i != n_seqs; ++i) {
 		bwa_seq_t *p = seqs + i;
@@ -100,7 +101,7 @@ void bwa_cal_sa_reg_gap(int tid, bwt_t *const bwt, int n_seqs, bwa_seq_t *seqs, 
 		p->sa = 0; p->type = BWA_TYPE_NO_MATCH; p->c1 = p->c2 = 0; p->n_aln = 0; p->aln = 0;
 		if (max_l < p->len) {
 			max_l = p->len;
-			w = (bwt_width_t*)realloc(w, (max_l + 1) * sizeof(bwt_width_t));
+			w = (bwt_width_t*)SAFE_REALLOC(w, (max_l + 1) * sizeof(bwt_width_t));
 			memset(w, 0, (max_l + 1) * sizeof(bwt_width_t));
 		}
 		bwt_cal_width(bwt, p->len, p->seq, w);
@@ -163,7 +164,7 @@ void bwa_aln_core(const char *prefix, const char *fn_fa, const gap_opt_t *opt)
 	ks = bwa_open_reads(opt->mode, fn_fa);
 
 	{ // load BWT
-		char *str = (char*)calloc(strlen(prefix) + 10, 1);
+		char *str = (char*)SAFE_CALLOC(strlen(prefix) + 10, 1);
 		strcpy(str, prefix); strcat(str, ".bwt");  bwt = bwt_restore_bwt(str);
 		free(str);
 	}
@@ -186,8 +187,8 @@ void bwa_aln_core(const char *prefix, const char *fn_fa, const gap_opt_t *opt)
 			int j;
 			pthread_attr_init(&attr);
 			pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
-			data = (thread_aux_t*)calloc(opt->n_threads, sizeof(thread_aux_t));
-			tid = (pthread_t*)calloc(opt->n_threads, sizeof(pthread_t));
+			data = (thread_aux_t*)SAFE_CALLOC(opt->n_threads, sizeof(thread_aux_t));
+			tid = (pthread_t*)SAFE_CALLOC(opt->n_threads, sizeof(pthread_t));
 			for (j = 0; j < opt->n_threads; ++j) {
 				data[j].tid = j; data[j].bwt = bwt;
 				data[j].n_seqs = n_seqs; data[j].seqs = seqs; data[j].opt = opt;

--- a/bwtgap.c
+++ b/bwtgap.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "memory.h"
 #include "bwtgap.h"
 #include "bwtaln.h"
 
@@ -13,9 +14,9 @@
 gap_stack_t *gap_init_stack2(int max_score)
 {
 	gap_stack_t *stack;
-	stack = (gap_stack_t*)calloc(1, sizeof(gap_stack_t));
+	stack = (gap_stack_t*)SAFE_CALLOC(1, sizeof(gap_stack_t));
 	stack->n_stacks = max_score;
-	stack->stacks = (gap_stack1_t*)calloc(stack->n_stacks, sizeof(gap_stack1_t));
+	stack->stacks = (gap_stack1_t*)SAFE_CALLOC(stack->n_stacks, sizeof(gap_stack1_t));
 	return stack;
 }
 
@@ -51,7 +52,7 @@ static inline void gap_push(gap_stack_t *stack, int i, bwtint_t k, bwtint_t l, i
 	q = stack->stacks + score;
 	if (q->n_entries == q->m_entries) {
 		q->m_entries = q->m_entries? q->m_entries<<1 : 4;
-		q->stack = (gap_entry_t*)realloc(q->stack, sizeof(gap_entry_t) * q->m_entries);
+		q->stack = (gap_entry_t*)SAFE_REALLOC(q->stack, sizeof(gap_entry_t) * q->m_entries);
 	}
 	p = q->stack + q->n_entries;
 	p->info = (u_int32_t)score<<21 | i; p->k = k; p->l = l;
@@ -110,7 +111,7 @@ bwt_aln1_t *bwt_match_gap(bwt_t *const bwt, int len, const ubyte_t *seq, bwt_wid
 	bwt_aln1_t *aln;
 
 	m_aln = 4; n_aln = 0;
-	aln = (bwt_aln1_t*)calloc(m_aln, sizeof(bwt_aln1_t));
+	aln = (bwt_aln1_t*)SAFE_CALLOC(m_aln, sizeof(bwt_aln1_t));
 
 	// check whether there are too many N
 	for (j = _j = 0; j < len; ++j)
@@ -177,7 +178,7 @@ bwt_aln1_t *bwt_match_gap(bwt_t *const bwt, int len, const ubyte_t *seq, bwt_wid
 				gap_shadow(l - k + 1, len, bwt->seq_len, e.last_diff_pos, width);
 				if (n_aln == m_aln) {
 					m_aln <<= 1;
-					aln = (bwt_aln1_t*)realloc(aln, m_aln * sizeof(bwt_aln1_t));
+					aln = (bwt_aln1_t*)SAFE_REALLOC(aln, m_aln * sizeof(bwt_aln1_t));
 					memset(aln + m_aln/2, 0, m_aln/2*sizeof(bwt_aln1_t));
 				}
 				p = aln + n_aln;

--- a/bwtindex.c
+++ b/bwtindex.c
@@ -216,7 +216,7 @@ int bwa_index(int argc, char *argv[]) // the "index" command
 		return 1;
 	}
 	if (prefix == 0) {
-		SAFE_MALLOC(prefix,(char*),(strlen(argv[optind]) + 4));
+		prefix=SAFE_MALLOC(strlen(argv[optind]) + 4);
 		strcpy(prefix, argv[optind]);
 		if (is_64) strcat(prefix, ".64");
 	}

--- a/bwtsw2_aux.c
+++ b/bwtsw2_aux.c
@@ -7,6 +7,7 @@
 #ifdef HAVE_PTHREAD
 #include <pthread.h>
 #endif
+#include "memory.h"
 #include "bntseq.h"
 #include "bwt_lite.h"
 #include "utils.h"
@@ -48,7 +49,7 @@ extern int bsw2_resolve_query_overlaps(bwtsw2_t *b, float mask_level);
 
 bsw2opt_t *bsw2_init_opt()
 {
-	bsw2opt_t *o = (bsw2opt_t*)calloc(1, sizeof(bsw2opt_t));
+	bsw2opt_t *o = (bsw2opt_t*)SAFE_CALLOC(1, sizeof(bsw2opt_t));
 	o->a = 1; o->b = 3; o->q = 5; o->r = 2; o->t = 30;
 	o->bw = 50;
 	o->max_ins = 20000;
@@ -73,11 +74,11 @@ void bsw2_destroy(bwtsw2_t *b)
 bwtsw2_t *bsw2_dup_no_cigar(const bwtsw2_t *b)
 {
 	bwtsw2_t *p;
-	p = calloc(1, sizeof(bwtsw2_t));
+	p = SAFE_CALLOC(1, sizeof(bwtsw2_t));
 	p->max = p->n = b->n;
 	if (b->n) {
 		kroundup32(p->max);
-		p->hits = calloc(p->max, sizeof(bsw2hit_t));
+		p->hits = SAFE_CALLOC(p->max, sizeof(bsw2hit_t));
 		memcpy(p->hits, b->hits, p->n * sizeof(bsw2hit_t));
 	}
 	return p;
@@ -100,10 +101,10 @@ void bsw2_extend_left(const bsw2opt_t *opt, bwtsw2_t *b, uint8_t *_query, int lq
 	int8_t mat[25];
 
 	bwa_fill_scmat(opt->a, opt->b, mat);
-	query = calloc(lq, 1);
+	query = SAFE_CALLOC(lq, 1);
 	// sort according to the descending order of query end
 	ks_introsort(hit, b->n, b->hits);
-	target = calloc(((lq + 1) / 2 * opt->a + opt->r) / opt->r + lq, 1);
+	target = SAFE_CALLOC(((lq + 1) / 2 * opt->a + opt->r) / opt->r + lq, 1);
 	// reverse _query
 	for (i = 0; i < lq; ++i) query[lq - i - 1] = _query[i];
 	// core loop
@@ -144,7 +145,7 @@ void bsw2_extend_rght(const bsw2opt_t *opt, bwtsw2_t *b, uint8_t *query, int lq,
 	int8_t mat[25];
 
 	bwa_fill_scmat(opt->a, opt->b, mat);
-	target = calloc(((lq + 1) / 2 * opt->a + opt->r) / opt->r + lq, 1);
+	target = SAFE_CALLOC(((lq + 1) / 2 * opt->a + opt->r) / opt->r + lq, 1);
 	for (i = 0; i < b->n; ++i) {
 		bsw2hit_t *p = b->hits + i;
 		int lt = ((lq - p->beg + 1) / 2 * opt->a + opt->r) / opt->r + lq;
@@ -192,7 +193,7 @@ static void gen_cigar(const bsw2opt_t *opt, int lq, uint8_t *seq[2], int64_t l_p
 		}
 #endif
 		if (q->cigar && (beg != 0 || end < lq)) { // write soft clipping
-			q->cigar = realloc(q->cigar, 4 * (q->n_cigar + 2));
+			q->cigar = SAFE_REALLOC(q->cigar, 4 * (q->n_cigar + 2));
 			if (beg != 0) {
 				memmove(q->cigar + 1, q->cigar, q->n_cigar * 4);
 				q->cigar[0] = beg<<4 | 4;
@@ -223,7 +224,7 @@ static void merge_hits(bwtsw2_t *b[2], int l, int is_reverse)
 	int i;
 	if (b[0]->n + b[1]->n > b[0]->max) {
 		b[0]->max = b[0]->n + b[1]->n;
-		b[0]->hits = realloc(b[0]->hits, b[0]->max * sizeof(bsw2hit_t));
+		b[0]->hits = SAFE_REALLOC(b[0]->hits, b[0]->max * sizeof(bsw2hit_t));
 	}
 	for (i = 0; i < b[1]->n; ++i) {
 		bsw2hit_t *p = b[0]->hits + b[0]->n + i;
@@ -251,9 +252,9 @@ static bwtsw2_t *bsw2_aln1_core(const bsw2opt_t *opt, const bntseq_t *bns, uint8
 	_b = bsw2_core(bns, opt, query, target, pool);
 	bwtl_destroy(query);
 	for (k = 0; k < 2; ++k) {
-		bb[k] = calloc(2, sizeof(void*));
-		bb[k][0] = calloc(1, sizeof(bwtsw2_t));
-		bb[k][1] = calloc(1, sizeof(bwtsw2_t));
+		bb[k] = SAFE_CALLOC(2, sizeof(void*));
+		bb[k][0] = SAFE_CALLOC(1, sizeof(bwtsw2_t));
+		bb[k][1] = SAFE_CALLOC(1, sizeof(bwtsw2_t));
 	}
 	for (k = 0; k < 2; ++k) { // separate _b into bb[2] based on the strand
 		for (j = 0; j < _b[k]->n; ++j) {
@@ -261,7 +262,7 @@ static bwtsw2_t *bsw2_aln1_core(const bsw2opt_t *opt, const bntseq_t *bns, uint8
 			p = bb[_b[k]->hits[j].is_rev][k];
 			if (p->n == p->max) {
 				p->max = p->max? p->max<<1 : 8;
-				p->hits = realloc(p->hits, p->max * sizeof(bsw2hit_t));
+				p->hits = SAFE_REALLOC(p->hits, p->max * sizeof(bsw2hit_t));
 			}
 			q = &p->hits[p->n++];
 			*q = _b[k]->hits[j];
@@ -340,7 +341,7 @@ static int fix_cigar(const bntseq_t *bns, bsw2hit_t *p, int n_cigar, uint32_t *c
 		uint32_t *cn;
 		bwtint_t kk = 0;
 		nc = mq[0] = mq[1] = nlen[0] = nlen[1] = 0;
-		cn = calloc(n_cigar + 3, 4);
+		cn = SAFE_CALLOC(n_cigar + 3, 4);
 		x = coor; y = 0;
 		for (i = j = 0; i < n_cigar; ++i) {
 			int op = cigar[i]&0xf, ln = cigar[i]>>4;
@@ -398,9 +399,9 @@ static void write_aux(const bsw2opt_t *opt, const bntseq_t *bns, int qlen, uint8
 	if (b->n<<1 < b->max) {
 		b->max = b->n;
 		kroundup32(b->max);
-		b->hits = realloc(b->hits, b->max * sizeof(bsw2hit_t));
+		b->hits = SAFE_REALLOC(b->hits, b->max * sizeof(bsw2hit_t));
 	}
-	b->aux = calloc(b->n, sizeof(bsw2aux_t));
+	b->aux = SAFE_CALLOC(b->n, sizeof(bsw2aux_t));
 	// generate CIGAR
 	gen_cigar(opt, qlen, seq, bns->l_pac, pac, b, name);
 	// fix CIGAR, generate mapQ, and write chromosomal position
@@ -559,7 +560,7 @@ static void bsw2_aln_core(bsw2seq_t *_seq, const bsw2opt_t *_opt, const bntseq_t
 	bsw2opt_t opt;
 	bsw2global_t *pool = bsw2_global_init();
 	bwtsw2_t **buf;
-	buf = calloc(_seq->n, sizeof(void*));
+	buf = SAFE_CALLOC(_seq->n, sizeof(void*));
 	for (x = 0; x < _seq->n; ++x) {
 		bsw2seq1_t *p = _seq->seq + x;
 		uint8_t *seq[2], *rseq[2];
@@ -570,10 +571,10 @@ static void bsw2_aln_core(bsw2seq_t *_seq, const bsw2opt_t *_opt, const bntseq_t
 		if (pool->max_l < l) { // then enlarge working space for aln_extend_core()
 			int tmp = ((l + 1) / 2 * opt.a + opt.r) / opt.r + l;
 			pool->max_l = l;
-			pool->aln_mem = realloc(pool->aln_mem, (tmp + 2) * 24);
+			pool->aln_mem = SAFE_REALLOC(pool->aln_mem, (tmp + 2) * 24);
 		}
 		// set seq[2] and rseq[2]
-		seq[0] = calloc(l * 4, 1);
+		seq[0] = SAFE_CALLOC(l * 4, 1);
 		seq[1] = seq[0] + l;
 		rseq[0] = seq[1] + l; rseq[1] = rseq[0] + l;
 		// convert sequences to 2-bit representation
@@ -586,7 +587,7 @@ static void bsw2_aln_core(bsw2seq_t *_seq, const bsw2opt_t *_opt, const bntseq_t
 			rseq[1][i] = c;
 		}
 		if (l - k < opt.t) { // too few unambiguous bases
-			buf[x] = calloc(1, sizeof(bwtsw2_t));
+			buf[x] = SAFE_CALLOC(1, sizeof(bwtsw2_t));
 			free(seq[0]); continue;
 		}
 		// alignment
@@ -618,7 +619,7 @@ static void bsw2_aln_core(bsw2seq_t *_seq, const bsw2opt_t *_opt, const bntseq_t
 		bsw2seq1_t *p = _seq->seq + x;
 		uint8_t *seq[2];
 		int i;
-		seq[0] = malloc(p->l * 2); seq[1] = seq[0] + p->l;
+		seq[0] = (uint8_t *)SAFE_MALLOC(p->l * 2); seq[1] = seq[0] + p->l;
 		for (i = 0; i < p->l; ++i) {
 			int c = nst_nt4_table[(int)p->seq[i]];
 			if (c >= 4) c = (int)(drand48() * 4);
@@ -674,16 +675,16 @@ static void process_seqs(bsw2seq_t *_seq, const bsw2opt_t *opt, const bntseq_t *
 		int j;
 		pthread_attr_init(&attr);
 		pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
-		data = (thread_aux_t*)calloc(opt->n_threads, sizeof(thread_aux_t));
-		tid = (pthread_t*)calloc(opt->n_threads, sizeof(pthread_t));
+		data = (thread_aux_t*)SAFE_CALLOC(opt->n_threads, sizeof(thread_aux_t));
+		tid = (pthread_t*)SAFE_CALLOC(opt->n_threads, sizeof(pthread_t));
 		for (j = 0; j < opt->n_threads; ++j) {
 			thread_aux_t *p = data + j;
 			p->tid = j; p->_opt = opt; p->bns = bns; p->is_pe = is_pe;
 			p->pac = pac; p->target = target;
-			p->_seq = calloc(1, sizeof(bsw2seq_t));
+			p->_seq = SAFE_CALLOC(1, sizeof(bsw2seq_t));
 			p->_seq->max = (_seq->n + opt->n_threads - 1) / opt->n_threads + 1;
 			p->_seq->n = 0;
-			p->_seq->seq = calloc(p->_seq->max, sizeof(bsw2seq1_t));
+			p->_seq->seq = SAFE_CALLOC(p->_seq->max, sizeof(bsw2seq1_t));
 		}
 		for (i = 0; i < _seq->n; ++i) { // assign sequences to each thread
 			bsw2seq_t *p = data[(i>>is_pe)%opt->n_threads]._seq;
@@ -728,7 +729,7 @@ void bsw2_aln(const bsw2opt_t *opt, const bntseq_t *bns, bwt_t * const target, c
 	bsw2seq_t *_seq;
 	bseq1_t *bseq;
 
-	pac = calloc(bns->l_pac/4+1, 1);
+	pac = SAFE_CALLOC(bns->l_pac/4+1, 1);
 	if (pac == 0) {
 		fprintf(stderr, "[bsw2_aln] insufficient memory!\n");
 		return;
@@ -738,7 +739,7 @@ void bsw2_aln(const bsw2opt_t *opt, const bntseq_t *bns, bwt_t * const target, c
 	fread(pac, 1, bns->l_pac/4+1, bns->fp_pac);
 	fp = xzopen(fn, "r");
 	ks = kseq_init(fp);
-	_seq = calloc(1, sizeof(bsw2seq_t));
+	_seq = SAFE_CALLOC(1, sizeof(bsw2seq_t));
 	if (fn2) {
 		fp2 = xzopen(fn2, "r");
 		ks2 = kseq_init(fp2);
@@ -749,7 +750,7 @@ void bsw2_aln(const bsw2opt_t *opt, const bntseq_t *bns, bwt_t * const target, c
 		if (n > _seq->max) {
 			_seq->max = n;
 			kroundup32(_seq->max);
-			_seq->seq = realloc(_seq->seq, _seq->max * sizeof(bsw2seq1_t));
+			_seq->seq = SAFE_REALLOC(_seq->seq, _seq->max * sizeof(bsw2seq1_t));
 		}
 		_seq->n = n;
 		for (i = 0; i < n; ++i) {

--- a/bwtsw2_chain.c
+++ b/bwtsw2_chain.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include "memory.h"
 #include "bwtsw2.h"
 
 typedef struct {
@@ -48,9 +49,9 @@ void bsw2_chain_filter(const bsw2opt_t *opt, int len, bwtsw2_t *b[2])
 	char *flag;
 	// initialization
 	n[0] = b[0]->n; n[1] = b[1]->n;
-	z[0] = calloc(n[0] + n[1], sizeof(hsaip_t));
+	z[0] = SAFE_CALLOC(n[0] + n[1], sizeof(hsaip_t));
 	z[1] = z[0] + n[0];
-	chain[0] = calloc(n[0] + n[1], sizeof(hsaip_t));
+	chain[0] = SAFE_CALLOC(n[0] + n[1], sizeof(hsaip_t));
 	for (k = j = 0; k < 2; ++k) {
 		for (i = 0; i < b[k]->n; ++i) {
 			bsw2hit_t *p = b[k]->hits + i;
@@ -73,7 +74,7 @@ void bsw2_chain_filter(const bsw2opt_t *opt, int len, bwtsw2_t *b[2])
 	}
 	//for (k = 0; k < m[0]; ++k) printf("%d, [%d,%d), [%d,%d)\n", chain[0][k].chain, chain[0][k].tbeg, chain[0][k].tend, chain[0][k].qbeg, chain[0][k].qend);
 	// filtering
-	flag = calloc(m[0] + m[1], 1);
+	flag = SAFE_CALLOC(m[0] + m[1], 1);
 	ks_introsort(hsaip, m[0] + m[1], chain[0]);
 	for (k = 1; k < m[0] + m[1]; ++k) {
 		hsaip_t *p = chain[0] + k;

--- a/bwtsw2_core.c
+++ b/bwtsw2_core.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <sys/resource.h>
 #include <assert.h>
+#include "memory.h"
 #include "bwt_lite.h"
 #include "bwtsw2.h"
 #include "bwt.h"
@@ -133,7 +134,7 @@ static void cut_tail(bsw2entry_t *u, int T, bsw2entry_t *aux)
 	if (u->n <= T) return;
 	if (aux->max < u->n) {
 		aux->max = u->n;
-		aux->array = (bsw2cell_t*)realloc(aux->array, aux->max * sizeof(bsw2cell_t));
+		aux->array = (bsw2cell_t*)SAFE_REALLOC(aux->array, aux->max * sizeof(bsw2cell_t));
 	}
 	a = (int*)aux->array;
 	for (i = n = 0; i != u->n; ++i)
@@ -184,7 +185,7 @@ static void merge_entry(const bsw2opt_t * __restrict opt, bsw2entry_t *u, bsw2en
 	int i;
 	if (u->n + v->n >= u->max) {
 		u->max = u->n + v->n;
-		u->array = (bsw2cell_t*)realloc(u->array, u->max * sizeof(bsw2cell_t));
+		u->array = (bsw2cell_t*)SAFE_REALLOC(u->array, u->max * sizeof(bsw2cell_t));
 	}
 	for (i = 0; i != v->n; ++i) {
 		bsw2cell_t *p = v->array + i;
@@ -202,7 +203,7 @@ static inline bsw2cell_t *push_array_p(bsw2entry_t *e)
 {
 	if (e->n == e->max) {
 		e->max = e->max? e->max<<1 : 256;
-		e->array = (bsw2cell_t*)realloc(e->array, sizeof(bsw2cell_t) * e->max);
+		e->array = (bsw2cell_t*)SAFE_REALLOC(e->array, sizeof(bsw2cell_t) * e->max);
 	}
 	return e->array + e->n;
 }
@@ -250,7 +251,7 @@ static void save_narrow_hits(const bwtl_t *bwtl, bsw2entry_t *u, bwtsw2_t *b1, i
 		if (p->G >= t && p->ql - p->qk + 1 <= IS) { // good narrow hit
 			if (b1->max == b1->n) {
 				b1->max = b1->max? b1->max<<1 : 4;
-				b1->hits = realloc(b1->hits, b1->max * sizeof(bsw2hit_t));
+				b1->hits = SAFE_REALLOC(b1->hits, b1->max * sizeof(bsw2hit_t));
 			}
 			q = &b1->hits[b1->n++];
 			q->k = p->qk; q->l = p->ql;
@@ -279,7 +280,7 @@ int bsw2_resolve_duphits(const bntseq_t *bns, const bwt_t *bwt, bwtsw2_t *b, int
 			else if (p->G > 0) ++n;
 		}
 		b->n = b->max = n;
-		b->hits = calloc(b->max, sizeof(bsw2hit_t));
+		b->hits = SAFE_CALLOC(b->max, sizeof(bsw2hit_t));
 		for (i = j = 0; i < old_n; ++i) {
 			bsw2hit_t *p = old_hits + i;
 			if (p->l - p->k + 1 <= IS) { // the hit is no so repetitive
@@ -399,9 +400,9 @@ bsw2global_t *bsw2_global_init()
 {
 	bsw2global_t *pool;
 	bsw2stack_t *stack;
-	pool = calloc(1, sizeof(bsw2global_t));
-	stack = calloc(1, sizeof(bsw2stack_t));
-	stack->pool = (mempool_t*)calloc(1, sizeof(mempool_t));
+	pool = SAFE_CALLOC(1, sizeof(bsw2global_t));
+	stack = SAFE_CALLOC(1, sizeof(bsw2stack_t));
+	stack->pool = (mempool_t*)SAFE_CALLOC(1, sizeof(mempool_t));
 	pool->stack = (void*)stack;
 	return pool;
 }
@@ -461,13 +462,13 @@ bwtsw2_t **bsw2_core(const bntseq_t *bns, const bsw2opt_t *opt, const bwtl_t *ta
 	rhash = kh_init(qintv);
 	init_bwtsw2(target, query, stack);
 	heap_size = opt->z;
-	heap = calloc(heap_size, sizeof(int));
+	heap = SAFE_CALLOC(heap_size, sizeof(int));
 	// initialize the return struct
-	b = (bwtsw2_t*)calloc(1, sizeof(bwtsw2_t));
+	b = (bwtsw2_t*)SAFE_CALLOC(1, sizeof(bwtsw2_t));
 	b->n = b->max = target->seq_len * 2;
-	b->hits = calloc(b->max, sizeof(bsw2hit_t));
-	b1 = (bwtsw2_t*)calloc(1, sizeof(bwtsw2_t));
-	b_ret = calloc(2, sizeof(void*));
+	b->hits = SAFE_CALLOC(b->max, sizeof(bsw2hit_t));
+	b1 = (bwtsw2_t*)SAFE_CALLOC(1, sizeof(bwtsw2_t));
+	b_ret = SAFE_CALLOC(2, sizeof(void*));
 	b_ret[0] = b; b_ret[1] = b1;
 	// initialize timer
 	getrusage(0, &last);

--- a/bwtsw2_pair.c
+++ b/bwtsw2_pair.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "memory.h"
 #include "bwt.h"
 #include "bntseq.h"
 #include "bwtsw2.h"
@@ -26,7 +27,7 @@ bsw2pestat_t bsw2_stat(int n, bwtsw2_t **buf, kstring_t *msg, int max_ins)
 	bsw2pestat_t r;
 
 	memset(&r, 0, sizeof(bsw2pestat_t));
-	isize = calloc(n, 8);
+	isize = SAFE_CALLOC(n, 8);
 	for (i = k = 0; i < n; i += 2) {
 		bsw2hit_t *t[2];
 		int l;
@@ -115,7 +116,7 @@ void bsw2_pair1(const bsw2opt_t *opt, int64_t l_pac, const uint8_t *pac, const b
 	if (end > l_pac) end = l_pac;
 	if (end - beg < l_mseq) return;
 	// generate the sequence
-	seq = malloc(l_mseq + (end - beg));
+	seq = (uint8_t*)SAFE_MALLOC(l_mseq + (end - beg));
 	ref = seq + l_mseq;
 	for (k = beg; k < end; ++k)
 		ref[k - beg] = pac[k>>2] >> ((~k&3)<<1) & 0x3;
@@ -194,7 +195,7 @@ void bsw2_pair(const bsw2opt_t *opt, int64_t l_pac, const uint8_t *pac, int n, b
 			a[which].flag |= BSW2_FLAG_RESCUED;
 			if (p[1]->max == 0) {
 				p[1]->max = 1;
-				p[1]->hits = malloc(sizeof(bsw2hit_t));
+				p[1]->hits = (bsw2hit_t*)SAFE_MALLOC(sizeof(bsw2hit_t));
 			}
 			p[1]->hits[0] = a[which];
 			p[1]->n = 1;

--- a/is.c
+++ b/is.c
@@ -25,6 +25,7 @@
  */
 
 #include <stdlib.h>
+#include "memory.h"
 
 typedef unsigned char ubyte_t;
 #define chr(i) (cs == sizeof(int) ? ((const int *)T)[i]:((const unsigned char *)T)[i])
@@ -105,7 +106,7 @@ static int sais_main(const unsigned char *T, int *SA, int fs, int n, int k, int 
 	if (k <= fs) {
 		C = SA + n;
 		B = (k <= (fs - k)) ? C + k : C;
-	} else if ((C = B = (int *) malloc(k * sizeof(int))) == NULL) return -2;
+	} else if ((C = B = (int *) SAFE_MALLOC(k * sizeof(int))) == NULL) return -2;
 	getCounts(T, C, n, k, cs);
 	getBuckets(C, B, k, 1);	/* find ends of buckets */
 	for (i = 0; i < n; ++i) SA[i] = 0;
@@ -163,7 +164,7 @@ static int sais_main(const unsigned char *T, int *SA, int fs, int n, int k, int 
 	if (k <= fs) {
 		C = SA + n;
 		B = (k <= (fs - k)) ? C + k : C;
-	} else if ((C = B = (int *) malloc(k * sizeof(int))) == NULL) return -2;
+	} else if ((C = B = (int *) SAFE_MALLOC(k * sizeof(int))) == NULL) return -2;
 	/* put all left-most S characters into their buckets */
 	getCounts(T, C, n, k, cs);
 	getBuckets(C, B, k, 1);	/* find ends of buckets */
@@ -204,7 +205,7 @@ int is_sa(const ubyte_t *T, int *SA, int n)
 int is_bwt(ubyte_t *T, int n)
 {
 	int *SA, i, primary = 0;
-	SA = (int*)calloc(n+1, sizeof(int));
+	SA = (int*)SAFE_CALLOC(n+1, sizeof(int));
 	is_sa(T, SA, n);
 
 	for (i = 0; i <= n; ++i) {

--- a/kbtree.h
+++ b/kbtree.h
@@ -51,7 +51,7 @@ typedef struct {
 	kbtree_##name##_t *kb_init_##name(int size)							\
 	{																	\
 		kbtree_##name##_t *b;											\
-		b = (kbtree_##name##_t*)calloc(1, sizeof(kbtree_##name##_t));	\
+		b = (kbtree_##name##_t*)SAFE_CALLOC(1, sizeof(kbtree_##name##_t));	\
 		b->t = ((size - 4 - sizeof(void*)) / (sizeof(void*) + sizeof(key_t)) + 1) >> 1; \
 		if (b->t < 2) {													\
 			free(b); return 0;											\
@@ -60,7 +60,7 @@ typedef struct {
 		b->off_ptr = 4 + b->n * sizeof(key_t);							\
 		b->ilen = (4 + sizeof(void*) + b->n * (sizeof(void*) + sizeof(key_t)) + 3) >> 2 << 2; \
 		b->elen = (b->off_ptr + 3) >> 2 << 2;							\
-		b->root = (kbnode_t*)calloc(1, b->ilen);						\
+		b->root = (kbnode_t*)SAFE_CALLOC(1, b->ilen);						\
 		++b->n_nodes;													\
 		return b;														\
 	}
@@ -69,7 +69,7 @@ typedef struct {
 		int i, max = 8;													\
 		kbnode_t *x, **top, **stack = 0;								\
 		if (b) {														\
-			top = stack = (kbnode_t**)calloc(max, sizeof(kbnode_t*));	\
+			top = stack = (kbnode_t**)SAFE_CALLOC(max, sizeof(kbnode_t*));	\
 			*top++ = (b)->root;											\
 			while (top != stack) {										\
 				x = *--top;												\
@@ -78,7 +78,7 @@ typedef struct {
 					if (__KB_PTR(b, x)[i]) {							\
 						if (top - stack == max) {						\
 							max <<= 1;									\
-							stack = (kbnode_t**)realloc(stack, max * sizeof(kbnode_t*)); \
+							stack = (kbnode_t**)SAFE_REALLOC(stack, max * sizeof(kbnode_t*)); \
 							top = stack + (max>>1);						\
 						}												\
 						*top++ = __KB_PTR(b, x)[i];						\
@@ -172,7 +172,7 @@ typedef struct {
 	static void __kb_split_##name(kbtree_##name##_t *b, kbnode_t *x, int i, kbnode_t *y) \
 	{																	\
 		kbnode_t *z;													\
-		z = (kbnode_t*)calloc(1, y->is_internal? b->ilen : b->elen);	\
+		z = (kbnode_t*)SAFE_CALLOC(1, y->is_internal? b->ilen : b->elen);	\
 		++b->n_nodes;													\
 		z->is_internal = y->is_internal;								\
 		z->n = b->t - 1;												\
@@ -210,7 +210,7 @@ typedef struct {
 		r = b->root;													\
 		if (r->n == 2 * b->t - 1) {										\
 			++b->n_nodes;												\
-			s = (kbnode_t*)calloc(1, b->ilen);							\
+			s = (kbnode_t*)SAFE_CALLOC(1, b->ilen);							\
 			b->root = s; s->is_internal = 1; s->n = 0;					\
 			__KB_PTR(b, s)[0] = r;										\
 			__kb_split_##name(b, s, 0, r);								\
@@ -332,13 +332,13 @@ typedef struct {
 #define __kb_traverse(key_t, b, __func) do {							\
 		int __kmax = 8;													\
 		__kbstack_t *__kstack, *__kp;									\
-		__kp = __kstack = (__kbstack_t*)calloc(__kmax, sizeof(__kbstack_t)); \
+		__kp = __kstack = (__kbstack_t*)SAFE_CALLOC(__kmax, sizeof(__kbstack_t)); \
 		__kp->x = (b)->root; __kp->i = 0;								\
 		for (;;) {														\
 			while (__kp->x && __kp->i <= __kp->x->n) {					\
 				if (__kp - __kstack == __kmax - 1) {					\
 					__kmax <<= 1;										\
-					__kstack = (__kbstack_t*)realloc(__kstack, __kmax * sizeof(__kbstack_t)); \
+					__kstack = (__kbstack_t*)SAFE_REALLOC(__kstack, __kmax * sizeof(__kbstack_t)); \
 					__kp = __kstack + (__kmax>>1) - 1;					\
 				}														\
 				(__kp+1)->i = 0; (__kp+1)->x = __kp->x->is_internal? __KB_PTR(b, __kp->x)[__kp->i] : 0; \

--- a/kseq.h
+++ b/kseq.h
@@ -50,9 +50,9 @@
 #define __KS_BASIC(type_t, __bufsize)								\
 	static inline kstream_t *ks_init(type_t f)						\
 	{																\
-		kstream_t *ks = (kstream_t*)calloc(1, sizeof(kstream_t));	\
+		kstream_t *ks = (kstream_t*)SAFE_CALLOC(1, sizeof(kstream_t));if(ks==NULL) return NULL;	\
 		ks->f = f;													\
-		ks->buf = (unsigned char*)malloc(__bufsize);				\
+		ks->buf = (unsigned char*)SAFE_MALLOC(__bufsize);				\
 		return ks;													\
 	}																\
 	static inline void ks_destroy(kstream_t *ks)					\
@@ -120,7 +120,7 @@ typedef struct __kstring_t {
 			if (str->m - str->l < (size_t)(i - ks->begin + 1)) {		\
 				str->m = str->l + (i - ks->begin) + 1;					\
 				kroundup32(str->m);										\
-				str->s = (char*)realloc(str->s, str->m);				\
+				str->s = (char*)SAFE_REALLOC(str->s, str->m);				\
 			}															\
 			memcpy(str->s + str->l, ks->buf + ks->begin, i - ks->begin); \
 			str->l = str->l + (i - ks->begin);							\
@@ -132,7 +132,7 @@ typedef struct __kstring_t {
 		}																\
 		if (str->s == 0) {												\
 			str->m = 1;													\
-			str->s = (char*)calloc(1, 1);								\
+			str->s = (char*)SAFE_CALLOC(1, 1);								\
 		} else if (delimiter == KS_SEP_LINE && str->l > 1 && str->s[str->l-1] == '\r') --str->l; \
 		str->s[str->l] = '\0';											\
 		return str->l;													\
@@ -151,7 +151,7 @@ typedef struct __kstring_t {
 #define __KSEQ_BASIC(SCOPE, type_t)										\
 	SCOPE kseq_t *kseq_init(type_t fd)									\
 	{																	\
-		kseq_t *s = (kseq_t*)calloc(1, sizeof(kseq_t));					\
+		kseq_t *s = (kseq_t*)SAFE_CALLOC(1, sizeof(kseq_t));					\
 		s->f = ks_init(fd);												\
 		return s;														\
 	}																	\
@@ -183,7 +183,7 @@ typedef struct __kstring_t {
 		if (c != '\n') ks_getuntil(ks, KS_SEP_LINE, &seq->comment, 0); /* read FASTA/Q comment */ \
 		if (seq->seq.s == 0) { /* we can do this in the loop below, but that is slower */ \
 			seq->seq.m = 256; \
-			seq->seq.s = (char*)malloc(seq->seq.m); \
+			seq->seq.s = (char*)SAFE_MALLOC(seq->seq.m); \
 		} \
 		while ((c = ks_getc(ks)) != -1 && c != '>' && c != '+' && c != '@') { \
 			if (c == '\n') continue; /* skip empty lines */ \
@@ -194,13 +194,13 @@ typedef struct __kstring_t {
 		if (seq->seq.l + 1 >= seq->seq.m) { /* seq->seq.s[seq->seq.l] below may be out of boundary */ \
 			seq->seq.m = seq->seq.l + 2; \
 			kroundup32(seq->seq.m); /* rounded to the next closest 2^k */ \
-			seq->seq.s = (char*)realloc(seq->seq.s, seq->seq.m); \
+			seq->seq.s = (char*)SAFE_REALLOC(seq->seq.s, seq->seq.m); \
 		} \
 		seq->seq.s[seq->seq.l] = 0;	/* null terminated string */ \
 		if (c != '+') return seq->seq.l; /* FASTA */ \
 		if (seq->qual.m < seq->seq.m) {	/* allocate memory for qual in case insufficient */ \
 			seq->qual.m = seq->seq.m; \
-			seq->qual.s = (char*)realloc(seq->qual.s, seq->qual.m); \
+			seq->qual.s = (char*)SAFE_REALLOC(seq->qual.s, seq->qual.m); \
 		} \
 		while ((c = ks_getc(ks)) != -1 && c != '\n'); /* skip the rest of '+' line */ \
 		if (c == -1) return -2; /* error: no quality string */ \

--- a/ksort.h
+++ b/ksort.h
@@ -72,7 +72,7 @@ typedef struct {
 		int curr, shift;												\
 																		\
 		a2[0] = array;													\
-		a2[1] = temp? temp : (type_t*)malloc(sizeof(type_t) * n);		\
+		a2[1] = temp? temp : (type_t*)SAFE_MALLOC(sizeof(type_t) * n);		\
 		for (curr = 0, shift = 0; (1ul<<shift) < n; ++shift) {			\
 			a = a2[curr]; b = a2[1-curr];								\
 			if (shift == 0) {											\
@@ -182,7 +182,7 @@ typedef struct {
 			return;														\
 		}																\
 		for (d = 2; 1ul<<d < n; ++d);									\
-		stack = (ks_isort_stack_t*)malloc(sizeof(ks_isort_stack_t) * ((sizeof(size_t)*d)+2)); \
+		stack = (ks_isort_stack_t*)SAFE_MALLOC(sizeof(ks_isort_stack_t) * ((sizeof(size_t)*d)+2)); \
 		top = stack; s = a; t = a + (n-1); d <<= 1;						\
 		while (1) {														\
 			if (s < t) {												\

--- a/kstring.c
+++ b/kstring.c
@@ -1,5 +1,6 @@
 #include <stdarg.h>
 #include <stdio.h>
+#include "memory.h"
 #include "kstring.h"
 
 int ksprintf(kstring_t *s, const char *fmt, ...)
@@ -12,7 +13,7 @@ int ksprintf(kstring_t *s, const char *fmt, ...)
 	if (l + 1 > s->m - s->l) {
 		s->m = s->l + l + 2;
 		kroundup32(s->m);
-		s->s = (char*)realloc(s->s, s->m);
+		s->s = (char*)SAFE_REALLOC(s->s, s->m);
 		va_start(ap, fmt);
 		l = vsnprintf(s->s + s->l, s->m - s->l, fmt, ap);
 	}
@@ -26,7 +27,7 @@ int ksprintf(kstring_t *s, const char *fmt, ...)
 int main()
 {
 	kstring_t *s;
-	s = (kstring_t*)calloc(1, sizeof(kstring_t));
+	s = (kstring_t*)SAFE_CALLOC(1, sizeof(kstring_t));
 	ksprintf(s, "abcdefg: %d", 100);
 	printf("%s\n", s->s);
 	free(s);

--- a/kstring.h
+++ b/kstring.h
@@ -21,7 +21,7 @@ static inline void ks_resize(kstring_t *s, size_t size)
 	if (s->m < size) {
 		s->m = size;
 		kroundup32(s->m);
-		s->s = (char*)realloc(s->s, s->m);
+		s->s = (char*)SAFE_REALLOC(s->s, s->m);
 	}
 }
 
@@ -30,7 +30,7 @@ static inline int kputsn(const char *p, int l, kstring_t *s)
 	if (s->l + l + 1 >= s->m) {
 		s->m = s->l + l + 2;
 		kroundup32(s->m);
-		s->s = (char*)realloc(s->s, s->m);
+		s->s = (char*)SAFE_REALLOC(s->s, s->m);
 	}
 	memcpy(s->s + s->l, p, l);
 	s->l += l;
@@ -48,7 +48,7 @@ static inline int kputc(int c, kstring_t *s)
 	if (s->l + 1 >= s->m) {
 		s->m = s->l + 2;
 		kroundup32(s->m);
-		s->s = (char*)realloc(s->s, s->m);
+		s->s = (char*)SAFE_REALLOC(s->s, s->m);
 	}
 	s->s[s->l++] = c;
 	s->s[s->l] = 0;
@@ -65,7 +65,7 @@ static inline int kputw(int c, kstring_t *s)
 	if (s->l + l + 1 >= s->m) {
 		s->m = s->l + l + 2;
 		kroundup32(s->m);
-		s->s = (char*)realloc(s->s, s->m);
+		s->s = (char*)SAFE_REALLOC(s->s, s->m);
 	}
 	for (x = l - 1; x >= 0; --x) s->s[s->l++] = buf[x];
 	s->s[s->l] = 0;
@@ -82,7 +82,7 @@ static inline int kputuw(unsigned c, kstring_t *s)
 	if (s->l + l + 1 >= s->m) {
 		s->m = s->l + l + 2;
 		kroundup32(s->m);
-		s->s = (char*)realloc(s->s, s->m);
+		s->s = (char*)SAFE_REALLOC(s->s, s->m);
 	}
 	for (i = l - 1; i >= 0; --i) s->s[s->l++] = buf[i];
 	s->s[s->l] = 0;
@@ -99,7 +99,7 @@ static inline int kputl(long c, kstring_t *s)
 	if (s->l + l + 1 >= s->m) {
 		s->m = s->l + l + 2;
 		kroundup32(s->m);
-		s->s = (char*)realloc(s->s, s->m);
+		s->s = (char*)SAFE_REALLOC(s->s, s->m);
 	}
 	for (x = l - 1; x >= 0; --x) s->s[s->l++] = buf[x];
 	s->s[s->l] = 0;

--- a/ksw.c
+++ b/ksw.c
@@ -478,7 +478,7 @@ int ksw_global(int qlen, const uint8_t *query, int tlen, const uint8_t *target, 
 	// allocate memory
 	n_col = qlen < 2*w+1? qlen : 2*w+1; // maximum #columns of the backtrack matrix
 	z = (uint8_t*)SAFE_MALLOC(n_col * tlen);
-	qp = (uint8_t*)SAFE_MALLOC(qlen * m);
+	qp = (int8_t*)SAFE_MALLOC(qlen * m);
 	eh = SAFE_CALLOC(qlen + 1, 8);
 	// generate the query profile
 	for (k = i = 0; k < m; ++k) {

--- a/ksw.c
+++ b/ksw.c
@@ -26,6 +26,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <emmintrin.h>
+#include "memory.h"
 #include "ksw.h"
 
 #ifdef __GNUC__
@@ -63,7 +64,7 @@ kswq_t *ksw_qinit(int size, int qlen, const uint8_t *query, int m, const int8_t 
 	size = size > 1? 2 : 1;
 	p = 8 * (3 - size); // # values per __m128i
 	slen = (qlen + p - 1) / p; // segmented length
-	q = (kswq_t*)malloc(sizeof(kswq_t) + 256 + 16 * slen * (m + 4)); // a single block of memory
+	q = (kswq_t*)SAFE_MALLOC(sizeof(kswq_t) + 256 + 16 * slen * (m + 4)); // a single block of memory
 	q->qp = (__m128i*)(((size_t)q + sizeof(kswq_t) + 15) >> 4 << 4); // align memory
 	q->H0 = q->qp + slen * m;
 	q->H1 = q->H0 + slen;
@@ -185,7 +186,7 @@ end_loop16:
 			if (n_b == 0 || (int32_t)b[n_b-1] + 1 != i) { // then append
 				if (n_b == m_b) {
 					m_b = m_b? m_b<<1 : 8;
-					b = (uint64_t*)realloc(b, 8 * m_b);
+					b = (uint64_t*)SAFE_REALLOC(b, 8 * m_b);
 				}
 				b[n_b++] = (uint64_t)imax<<32 | i;
 			} else if ((int)(b[n_b-1]>>32) < imax) b[n_b-1] = (uint64_t)imax<<32 | i; // modify the last
@@ -288,7 +289,7 @@ end_loop8:
 			if (n_b == 0 || (int32_t)b[n_b-1] + 1 != i) {
 				if (n_b == m_b) {
 					m_b = m_b? m_b<<1 : 8;
-					b = (uint64_t*)realloc(b, 8 * m_b);
+					b = (uint64_t*)SAFE_REALLOC(b, 8 * m_b);
 				}
 				b[n_b++] = (uint64_t)imax<<32 | i;
 			} else if ((int)(b[n_b-1]>>32) < imax) b[n_b-1] = (uint64_t)imax<<32 | i; // modify the last
@@ -368,8 +369,8 @@ int ksw_extend(int qlen, const uint8_t *query, int tlen, const uint8_t *target, 
 	int i, j, k, gapoe = gapo + gape, beg, end, max, max_i, max_j, max_gap, max_ie, gscore, max_off;
 	if (h0 < 0) h0 = 0;
 	// allocate memory
-	qp = malloc(qlen * m);
-	eh = calloc(qlen + 1, 8);
+	qp = (int8_t *)SAFE_MALLOC(qlen * m);
+	eh = SAFE_CALLOC(qlen + 1, 8);
 	// generate the query profile
 	for (k = i = 0; k < m; ++k) {
 		const int8_t *p = &mat[k * m];
@@ -460,7 +461,7 @@ static inline uint32_t *push_cigar(int *n_cigar, int *m_cigar, uint32_t *cigar, 
 	if (*n_cigar == 0 || op != (cigar[(*n_cigar) - 1]&0xf)) {
 		if (*n_cigar == *m_cigar) {
 			*m_cigar = *m_cigar? (*m_cigar)<<1 : 4;
-			cigar = realloc(cigar, (*m_cigar) << 2);
+			cigar = SAFE_REALLOC(cigar, (*m_cigar) << 2);
 		}
 		cigar[(*n_cigar)++] = len<<4 | op;
 	} else cigar[(*n_cigar)-1] += len<<4;
@@ -476,9 +477,9 @@ int ksw_global(int qlen, const uint8_t *query, int tlen, const uint8_t *target, 
 	if (n_cigar_) *n_cigar_ = 0;
 	// allocate memory
 	n_col = qlen < 2*w+1? qlen : 2*w+1; // maximum #columns of the backtrack matrix
-	z = malloc(n_col * tlen);
-	qp = malloc(qlen * m);
-	eh = calloc(qlen + 1, 8);
+	z = (uint8_t*)SAFE_MALLOC(n_col * tlen);
+	qp = (uint8_t*)SAFE_MALLOC(qlen * m);
+	eh = SAFE_CALLOC(qlen + 1, 8);
 	// generate the query profile
 	for (k = i = 0; k < m; ++k) {
 		const int8_t *p = &mat[k * m];
@@ -619,7 +620,7 @@ int main(int argc, char *argv[])
 		if (!forward_only) { // reverse
 			if ((int)ksq->seq.m > max_rseq) {
 				max_rseq = ksq->seq.m;
-				rseq = (uint8_t*)realloc(rseq, max_rseq);
+				rseq = (uint8_t*)SAFE_REALLOC(rseq, max_rseq);
 			}
 			for (i = 0, j = ksq->seq.l - 1; i < (int)ksq->seq.l; ++i, --j)
 				rseq[j] = ksq->seq.s[i] == 4? 4 : 3 - ksq->seq.s[i];

--- a/kvec.h
+++ b/kvec.h
@@ -60,7 +60,7 @@ int main() {
 #define kv_size(v) ((v).n)
 #define kv_max(v) ((v).m)
 
-#define kv_resize(type, v, s)  ((v).m = (s), (v).a = (type*)realloc((v).a, sizeof(type) * (v).m))
+#define kv_resize(type, v, s)  ((v).m = (s), (v).a = (type*)SAFE_REALLOC((v).a, sizeof(type) * (v).m))
 
 #define kv_copy(type, v1, v0) do {							\
 		if ((v1).m < (v0).n) kv_resize(type, v1, (v0).n);	\
@@ -71,19 +71,19 @@ int main() {
 #define kv_push(type, v, x) do {									\
 		if ((v).n == (v).m) {										\
 			(v).m = (v).m? (v).m<<1 : 2;							\
-			(v).a = (type*)realloc((v).a, sizeof(type) * (v).m);	\
+			(v).a = (type*)SAFE_REALLOC((v).a, sizeof(type) * (v).m);	\
 		}															\
 		(v).a[(v).n++] = (x);										\
 	} while (0)
 
 #define kv_pushp(type, v) ((((v).n == (v).m)?							\
 						   ((v).m = ((v).m? (v).m<<1 : 2),				\
-							(v).a = (type*)realloc((v).a, sizeof(type) * (v).m), 0)	\
+							(v).a = (type*)SAFE_REALLOC((v).a, sizeof(type) * (v).m), 0)	\
 						   : 0), &(v).a[(v).n++])
 
 #define kv_a(type, v, i) (((v).m <= (size_t)(i)? \
 						  ((v).m = (v).n = (i) + 1, kv_roundup32((v).m), \
-						   (v).a = (type*)realloc((v).a, sizeof(type) * (v).m), 0) \
+						   (v).a = (type*)SAFE_REALLOC((v).a, sizeof(type) * (v).m), 0) \
 						  : (v).n <= (size_t)(i)? (v).n = (i) + 1 \
 						  : 0), (v).a[(i)])
 

--- a/memory.c
+++ b/memory.c
@@ -1,34 +1,38 @@
+/**
+ * safe calls to alloc function : abort in case of error
+ * Pierre Lindenbaum PhD.
+ */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 
-#define TEST_MEMORY(PTR,SIZEOF) if(PTR==NULL) {fprintf(stderr,"[%s:%d]Out of memory(%d bytes).\n",file,line,SIZEOF); exit(EXIT_FAILURE);}
+#define TEST_MEMORY(PTR,SIZEOF) if(PTR==NULL) {fprintf(stderr,"[%s:%d]Out of memory(%ld bytes).\n",file,line,SIZEOF); exit(EXIT_FAILURE);}
 
-(void*)_safeMalloc(size_t n,const char* file,int line)
+void* _safeMalloc(size_t n,const char* file,int line)
 	{
 	void* p=malloc(n);
 	TEST_MEMORY(p,n);
 	return p;
 	}
 	
-(void*)_safeCalloc(size_t n,size_t m,const char* file,int line)
+void* _safeCalloc(size_t n,size_t m,const char* file,int line)
 	{
 	void* p=calloc(n,m);
 	TEST_MEMORY(p,n*m);
 	return p;
 	}
 	
-(void*)_safeRealloc(void* ptr,size_t N,const char* file,int line)
+void* _safeRealloc(void* ptr,size_t N,const char* file,int line)
 	{
 	void* p=realloc(ptr,N);
 	TEST_MEMORY(p,N);
 	return p;
 	}
 	
-(char*)_safeStrdup(const char* s,const char* file,int line)	
+char* _safeStrdup(const char* s,const char* file,int line)	
 	{
-	char* p=stdup(s);
+	char* p=strdup(s);
 	TEST_MEMORY(p,strlen(s));
 	return p;
 	}

--- a/memory.c
+++ b/memory.c
@@ -1,0 +1,34 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+
+#define TEST_MEMORY(PTR,SIZEOF) if(PTR==NULL) {fprintf(stderr,"[%s:%d]Out of memory(%d bytes).\n",file,line,SIZEOF); exit(EXIT_FAILURE);}
+
+(void*)_safeMalloc(size_t n,const char* file,int line)
+	{
+	void* p=malloc(n);
+	TEST_MEMORY(p,n);
+	return p;
+	}
+	
+(void*)_safeCalloc(size_t n,size_t m,const char* file,int line)
+	{
+	void* p=calloc(n,m);
+	TEST_MEMORY(p,n*m);
+	return p;
+	}
+	
+(void*)_safeRealloc(void* ptr,size_t N,const char* file,int line)
+	{
+	void* p=realloc(ptr,N);
+	TEST_MEMORY(p,N);
+	return p;
+	}
+	
+(char*)_safeStrdup(const char* s,const char* file,int line)	
+	{
+	char* p=stdup(s);
+	TEST_MEMORY(p,strlen(s));
+	return p;
+	}

--- a/memory.h
+++ b/memory.h
@@ -1,0 +1,41 @@
+#ifndef BWA_MEMORY_H
+#define BWA_MEMORY_H
+#include <stddef.h>
+#include <stdlib.h>
+
+extern void* _safeMalloc(size_t,const char* file,int line);
+extern void* _safeCalloc(size_t,size_t,const char* file,int line);
+extern void* _safeRealloc(void*,size_t,const char* file,int line);
+extern char* _safeStrdup(const char*,const char* file,int line);
+
+#define SAFE_MALLOC(SIZEOF) _safeMalloc(SIZEOF,__FILE__,__LINE__)
+#define SAFE_CALLOC(N,SIZEOF) _safeCalloc(N,SIZEOF,__FILE__,__LINE__)
+#define SAFE_REALLOC(PTR,SIZEOF) _safeRealloc(PTR,SIZEOF,__FILE__,__LINE__)
+#define SAFE_STRDUP(s) _safeStrdup(s,__FILE__,__LINE__)
+
+#ifdef AC_KSEQ_H
+#error "insert memory.h before kseq.h"
+#endif
+
+#ifdef __AC_KHASH_H
+#error "insert memory.h before kash.h"
+#endif
+
+#ifdef __AC_KBTREE_H
+#error "insert memory.h before kbtree.h"
+#endif
+
+/** for khash.h */
+
+#ifndef kcalloc
+#define kcalloc(N,Z) SAFE_CALLOC(N,Z)
+#endif
+#ifndef kmalloc
+#define kmalloc(Z) SAFE_MALLOC(Z)
+#endif
+#ifndef krealloc
+#define krealloc(P,Z) SAFE_REALLOC(P,Z)
+#endif
+
+#endif
+

--- a/memory.h
+++ b/memory.h
@@ -1,3 +1,7 @@
+/**
+ * safe calls to alloc function : abort in case of error
+ * Pierre Lindenbaum PhD.
+ */
 #ifndef BWA_MEMORY_H
 #define BWA_MEMORY_H
 #include <stddef.h>

--- a/utils.c
+++ b/utils.c
@@ -33,8 +33,8 @@
 #include <errno.h>
 #include <sys/resource.h>
 #include <sys/time.h>
+#include "memory.h"
 #include "utils.h"
-
 #include "ksort.h"
 #define pair64_lt(a, b) ((a).x < (b).x || ((a).x == (b).x && (a).y < (b).y))
 KSORT_INIT(128, pair64_t, pair64_lt)

--- a/utils.c
+++ b/utils.c
@@ -62,7 +62,7 @@ FILE *err_xopen_core(const char *func, const char *fn, const char *mode)
 FILE *err_xreopen_core(const char *func, const char *fn, const char *mode, FILE *fp)
 {
 	if (freopen(fn, mode, fp) == 0) {
-		fprintf(stderr, "[%s] fail to open file '%s': ", func, fn);
+		fprintf(stderr, "[%s] fail to open file '%s'", func, fn);
 		perror(NULL);
 		fprintf(stderr, "Abort!\n");
 		abort();


### PR DESCRIPTION
I added `memory.h` and `memory.c`

replaced all calls to malloc by SAFE_MALLOC,  realloc etc..

_SAFE_MALLOC_ is a macro calling _safeMalloc(size_t n,__FILE__,**LINE**) it allocates the memory or exit(-1) on failure. The program exits after printing an error message.

_SAFE_REALLOC_ calls _safeRealloc ... etc...
