### PR TITLE
Adds check that ref sequence names do not contain semicolon during index

### DIFF
--- a/bntseq.c
+++ b/bntseq.c
@@ -200,6 +200,10 @@ static uint8_t *add1(const kseq_t *seq, bntseq_t *bns, uint8_t *pac, int64_t *m_
 		bns->anns = (bntann1_t*)realloc(bns->anns, *m_seqs * sizeof(bntann1_t));
 	}
 	p = bns->anns + bns->n_seqs;
+	if (strchr(seq->name.s, ';')) {
+	  fputs("\n", stderr);
+	  err_fatal(__func__, "Error: Reference contains invalid character ';' in sequence name \"%s\"\n", seq->name.s);
+	}
 	p->name = strdup((char*)seq->name.s);
 	p->anno = seq->comment.s? strdup((char*)seq->comment.s) : strdup("(null)");
 	p->gi = 0; p->len = seq->seq.l;


### PR DESCRIPTION
If a user's input reference sequences have a semicolon in the name, this clashes with the use of the semicolon as a delimiter in the `XA:Z` tag. It may be useful to warn users of this potential issue during the bwa index step. For example, if users use `xa2multi.pl` to make multiple entries from the XA tag and pass to samtools view, samtools view will only look for the refname prior to the semicolon.
