### PR TITLE
Added filenames to "Unmatched SAI magic" message

### DIFF
--- a/bwase.c
+++ b/bwase.c
@@ -525,7 +525,7 @@ void bwa_sai2sam_se_core(const char *prefix, const char *fn_sa, const char *fn_f
 	m_aln = 0;
 	err_fread_noeof(magic, 1, 4, fp_sa);
 	if (strncmp(magic, SAI_MAGIC, 4) != 0) {
-		fprintf(stderr, "[E::%s] Unmatched SAI magic. Please re-run `aln' with the same version of bwa.\n", __func__);
+		fprintf(stderr, "[E::%s] Unmatched SAI magic in file \"%s\". Please re-run `aln' with the same version of bwa.\n", __func__, fn_sa);
 		exit(1);
 	}
 	err_fread_noeof(&opt, sizeof(gap_opt_t), 1, fp_sa);


### PR DESCRIPTION
This was helpful for me debugging a problem so I thought others may find it useful. I realize that the loop over two files may seem silly to some, but it made sense from a "DRY" perspective since I wanted to output which file did not have the magic number.

Here's an example:

```
# dd if=/dev/urandom of=./chr1_2.sai count=81 bs=1K
# ~/bwa/bwa sampe ./chr1.fa chr1_1.sai chr1_2.sai small1.fq small2.fq > bad.sam
[E::bwa_sai2sam_pe_core] Unmatched SAI magic in file "chr1_2.sai". Please re-run `aln' with the same version of bwa.
```
