### PR TITLE
fix duplicate PG lines in bwape and bwase

### DIFF
--- a/bwape.c
+++ b/bwape.c
@@ -49,7 +49,6 @@ int bwa_approx_mapQ(const bwa_seq_t *p, int mm);
 void bwa_print_sam1(const bntseq_t *bns, bwa_seq_t *p, const bwa_seq_t *mate, int mode, int max_top2);
 bntseq_t *bwa_open_nt(const char *prefix);
 void bwa_print_sam_SQ(const bntseq_t *bns);
-void bwa_print_sam_PG();
 
 pe_opt_t *bwa_init_pe_opt()
 {
@@ -671,7 +670,6 @@ void bwa_sai2sam_pe_core(const char *prefix, char *const fn_sa[2], char *const f
 
 	// core loop
 	bwa_print_sam_hdr(bns, rg_line);
-	bwa_print_sam_PG();
 	while ((seqs[0] = bwa_read_seq(ks[0], 0x40000, &n_seqs, opt0.mode, opt0.trim_qual)) != 0) {
 		int cnt_chg;
 		isize_info_t ii;

--- a/bwase.c
+++ b/bwase.c
@@ -19,8 +19,6 @@
 
 int g_log_n[256];
 
-void bwa_print_sam_PG();
-
 void bwa_aln2seq_core(int n_aln, const bwt_aln1_t *aln, bwa_seq_t *s, int set_main, int n_multi)
 {
 	int i, cnt, best;
@@ -530,7 +528,6 @@ void bwa_sai2sam_se_core(const char *prefix, const char *fn_sa, const char *fn_f
 	}
 	err_fread_noeof(&opt, sizeof(gap_opt_t), 1, fp_sa);
 	bwa_print_sam_hdr(bns, rg_line);
-	//bwa_print_sam_PG();
 	// set ks
 	ks = bwa_open_reads(opt.mode, fn_fa);
 	// core loop

--- a/main.c
+++ b/main.c
@@ -57,11 +57,6 @@ static int usage()
 	return 1;
 }
 
-void bwa_print_sam_PG()
-{
-	err_printf("@PG\tID:bwa\tPN:bwa\tVN:%s\n", PACKAGE_VERSION);
-}
-
 int main(int argc, char *argv[])
 {
 	int i, ret;


### PR DESCRIPTION
ff6faf8 introduced code to print the PG lines for `bwamem.c`. Since `bwape.c` and `bwase.c` already had code to print a PG line (albeit without CL), this resulted in duplicate @PG entries in the latter programs (which violates the unique-id requirement for PG records per the SAM spec).

This pull request just removes the older printing of the PG lines, leaving printing in place within `bwa_print_sam_hdr`.
