### PR TITLE
Clarify documentation of bwa mem -M

### DIFF
--- a/bwa.1
+++ b/bwa.1
@@ -312,7 +312,8 @@ uses soft clipping for the primary alignment and hard clipping for
 supplementary alignments.
 .TP
 .B -M
-Mark shorter split hits as secondary (for Picard compatibility).
+Mark shorter split hits of a chimeric alignment as 'secondary alignment' (SAM flag 0x100)
+instead of 'supplementary alignment' (flag 0x800) (for Picard<1.96 compatibility).
 .TP
 .BI -v \ INT
 Control the verbose level of the output. This option has not been fully

--- a/fastmap.c
+++ b/fastmap.c
@@ -277,7 +277,8 @@ int main_mem(int argc, char *argv[])
 		fprintf(stderr, "       -C            append FASTA/FASTQ comment to SAM output\n");
 		fprintf(stderr, "       -V            output the reference FASTA header in the XR tag\n");
 		fprintf(stderr, "       -Y            use soft clipping for supplementary alignments\n");
-		fprintf(stderr, "       -M            mark shorter split hits as secondary\n\n");
+		fprintf(stderr, "       -M            mark shorter split hits of a chimeric alignment as\n");
+		fprintf(stderr, "                     'secondary' instead of 'supplementary'\n\n");
 		fprintf(stderr, "       -I FLOAT[,FLOAT[,INT[,INT]]]\n");
 		fprintf(stderr, "                     specify the mean, standard deviation (10%% of the mean if absent), max\n");
 		fprintf(stderr, "                     (4 sigma from the mean if absent) and min of the insert size distribution.\n");


### PR DESCRIPTION
References:
- https://www.biostars.org/p/97323/
- http://sourceforge.net/p/samtools/mailman/message/31227887/ for the Picard version in which support for 'supplementary alignment' flag was introduced.
