### PR TITLE
Add @HD tag to SAM header

### DIFF
--- a/bwa.c
+++ b/bwa.c
@@ -271,6 +271,7 @@ void bwa_print_sam_hdr(const bntseq_t *bns, const char *rg_line)
 {
 	int i;
 	extern char *bwa_pg;
+	ksprintf(str, "@HD\tVN:1.4\tSO:unknown\n");
 	for (i = 0; i < bns->n_seqs; ++i)
 		err_printf("@SQ\tSN:%s\tLN:%d\n", bns->anns[i].name, bns->anns[i].len);
 	if (rg_line) err_printf("%s\n", rg_line);
@@ -283,6 +284,7 @@ void bwa_format_sam_hdr(const bntseq_t *bns, const char *rg_line, kstring_t *str
 	int i;
 	extern char *bwa_pg;
 	str->l = 0; str->s = 0;
+	ksprintf(str, "@HD\tVN:1.4\tSO:unknown\n");
 	for (i = 0; i < bns->n_seqs; ++i) 
 		ksprintf(str, "@SQ\tSN:%s\tLN:%d\n", bns->anns[i].name, bns->anns[i].len);
 	if (rg_line) ksprintf(str, "%s\n", rg_line);


### PR DESCRIPTION
This pull request adds an @HD tag to SAM header with a sort order of unknown.  This helps us to avoid confusing tools which mistakenly default to a sort order of coordinate.
