### PR TITLE
wrong function to print @HD line in bwa_print_sam_hdr

### DIFF
--- a/bwa.c
+++ b/bwa.c
@@ -271,7 +271,7 @@ void bwa_print_sam_hdr(const bntseq_t *bns, const char *rg_line)
 {
 	int i;
 	extern char *bwa_pg;
-	ksprintf(str, "@HD\tVN:1.4\tSO:unknown\n");
+	err_printf("@HD\tVN:1.4\tSO:unknown\n");
 	for (i = 0; i < bns->n_seqs; ++i)
 		err_printf("@SQ\tSN:%s\tLN:%d\n", bns->anns[i].name, bns->anns[i].len);
 	if (rg_line) err_printf("%s\n", rg_line);


### PR DESCRIPTION
bwa did not compile, my guess that err_printf has to be used to print the `@HD` line
