### PR TITLE
Fix leaked memory in bwamem when there are insufficient pairs for isize statistics

### DIFF
--- a/bwamem_pair.c
+++ b/bwamem_pair.c
@@ -70,6 +70,7 @@ void mem_pestat(const mem_opt_t *opt, int64_t l_pac, int n, const mem_alnreg_v *
 		if (q->n < MIN_DIR_CNT) {
 			fprintf(stderr, "[M::%s] skip orientation %c%c as there are not enough pairs\n", __func__, "FR"[d>>1&1], "FR"[d&1]);
 			r->failed = 1;
+			free(q->a);
 			continue;
 		} else fprintf(stderr, "[M::%s] analyzing insert size distribution for orientation %c%c...\n", __func__, "FR"[d>>1&1], "FR"[d&1]);
 		ks_introsort_64(q->n, q->a);


### PR DESCRIPTION
In mem_pestat, when there is insufficient data the code hits a 'continue' without freeing the relevant insert size vector, resulting in a small memory leak.  This patch simply inserts a call to 'free' before the continue.
