### PR TITLE
-q option to put seq/qual strings in secondary alignments

### DIFF
--- a/bwamem.c
+++ b/bwamem.c
@@ -869,7 +869,7 @@ void mem_aln2sam(const mem_opt_t *opt, const bntseq_t *bns, kstring_t *str, bseq
 	kputc('\t', str);
 
 	// print SEQ and QUAL
-	if (p->flag & 0x100) { // for secondary alignments, don't write SEQ and QUAL
+	if ((p->flag & 0x100) && !(opt->flag&MEM_F_SEC_SEQ_QUAL)) { // for secondary alignments, don't write SEQ and QUAL unless told to
 		kputsn("*\t*", 3, str);
 	} else if (!p->is_rev) { // the forward strand
 		int i, qb = 0, qe = s->l_seq;

--- a/bwamem.h
+++ b/bwamem.h
@@ -11,16 +11,16 @@
 struct __smem_i;
 typedef struct __smem_i smem_i;
 
-#define MEM_F_PE        0x2
-#define MEM_F_NOPAIRING 0x4
-#define MEM_F_ALL       0x8
-#define MEM_F_NO_MULTI  0x10
-#define MEM_F_NO_RESCUE 0x20
-#define MEM_F_SELF_OVLP 0x40
-#define MEM_F_ALN_REG   0x80
-#define MEM_F_REF_HDR	0x100
-#define MEM_F_SOFTCLIP  0x200
-
+#define MEM_F_PE           0x2
+#define MEM_F_NOPAIRING    0x4
+#define MEM_F_ALL          0x8
+#define MEM_F_NO_MULTI     0x10
+#define MEM_F_NO_RESCUE    0x20
+#define MEM_F_SELF_OVLP    0x40
+#define MEM_F_ALN_REG      0x80
+#define MEM_F_REF_HDR      0x100
+#define MEM_F_SOFTCLIP     0x200
+#define MEM_F_SEC_SEQ_QUAL 0x400  
 typedef struct {
 	int a, b;               // match score and mismatch penalty
 	int o_del, e_del;

--- a/fastmap.c
+++ b/fastmap.c
@@ -55,7 +55,7 @@ int main_mem(int argc, char *argv[])
 
 	opt = mem_opt_init();
 	memset(&opt0, 0, sizeof(mem_opt_t));
-	while ((c = getopt(argc, argv, "epaFMCSPHVYjk:c:v:s:r:t:R:A:B:O:E:U:w:L:d:T:Q:D:m:I:N:W:x:G:h:y:K:")) >= 0) {
+	while ((c = getopt(argc, argv, "epaFMCSPHVYjkq:c:v:s:r:t:R:A:B:O:E:U:w:L:d:T:Q:D:m:I:N:W:x:G:h:y:K:")) >= 0) {
 		if (c == 'k') opt->min_seed_len = atoi(optarg), opt0.min_seed_len = 1;
 		else if (c == 'x') mode = optarg;
 		else if (c == 'w') opt->w = atoi(optarg), opt0.w = 1;
@@ -73,6 +73,7 @@ int main_mem(int argc, char *argv[])
 		else if (c == 'F') opt->flag |= MEM_F_ALN_REG;
 		else if (c == 'Y') opt->flag |= MEM_F_SOFTCLIP;
 		else if (c == 'V') opt->flag |= MEM_F_REF_HDR;
+		else if (c == 'q') opt->flag |= MEM_F_SEC_SEQ_QUAL;
 		else if (c == 'c') opt->max_occ = atoi(optarg), opt0.max_occ = 1;
 		else if (c == 'd') opt->zdrop = atoi(optarg), opt0.zdrop = 1;
 		else if (c == 'v') bwa_verbose = atoi(optarg);
@@ -174,6 +175,7 @@ int main_mem(int argc, char *argv[])
 		fprintf(stderr, "       -T INT        minimum score to output [%d]\n", opt->T);
 		fprintf(stderr, "       -h INT[,INT]  if there are <INT hits with score >80%% of the max score, output all in XA [%d,%d]\n", opt->max_XA_hits, opt->max_XA_hits_alt);
 		fprintf(stderr, "       -a            output all alignments for SE or unpaired PE\n");
+		fprintf(stderr, "       -q            write seq/qual strings for secondary alignments\n");
 		fprintf(stderr, "       -C            append FASTA/FASTQ comment to SAM output\n");
 		fprintf(stderr, "       -V            output the reference FASTA header in the XR tag\n");
 		fprintf(stderr, "       -Y            use soft clipping for supplementary alignments\n");


### PR DESCRIPTION
Users should have the option to put the seq/qual strings in the secondary alignments (if -a is specified)...for example, I am doing a batch set of alignments where I have many similar reference sequences, so I expect multiple alignments, but one in particular (which may not be the primary alignment) needs further processing.
