### PR TITLE
mmap'ed access to reference files

### DIFF
--- a/bwa.c
+++ b/bwa.c
@@ -231,7 +231,7 @@ char *bwa_idx_infer_prefix(const char *hint)
 	}
 }
 
-bwt_t *bwa_idx_load_bwt(const char *hint)
+bwt_t *bwa_idx_load_bwt(const char *hint, int use_mmap)
 {
 	char *tmp, *prefix;
 	bwt_t *bwt;
@@ -242,14 +242,14 @@ bwt_t *bwa_idx_load_bwt(const char *hint)
 	}
 	tmp = calloc(strlen(prefix) + 5, 1);
 	strcat(strcpy(tmp, prefix), ".bwt"); // FM-index
-	bwt = bwt_restore_bwt(tmp);
+	bwt = bwt_restore_bwt(tmp, use_mmap);
 	strcat(strcpy(tmp, prefix), ".sa");  // partial suffix array (SA)
 	bwt_restore_sa(tmp, bwt);
 	free(tmp); free(prefix);
 	return bwt;
 }
 
-bwaidx_t *bwa_idx_load_from_disk(const char *hint, int which)
+bwaidx_t *bwa_idx_load_from_disk(const char *hint, int which, int use_mmap)
 {
 	bwaidx_t *idx;
 	char *prefix;
@@ -259,7 +259,7 @@ bwaidx_t *bwa_idx_load_from_disk(const char *hint, int which)
 		return 0;
 	}
 	idx = calloc(1, sizeof(bwaidx_t));
-	if (which & BWA_IDX_BWT) idx->bwt = bwa_idx_load_bwt(hint);
+	if (which & BWA_IDX_BWT) idx->bwt = bwa_idx_load_bwt(hint, use_mmap);
 	if (which & BWA_IDX_BNS) {
 		int i, c;
 		idx->bns = bns_restore(prefix);
@@ -278,9 +278,9 @@ bwaidx_t *bwa_idx_load_from_disk(const char *hint, int which)
 	return idx;
 }
 
-bwaidx_t *bwa_idx_load(const char *hint, int which)
+bwaidx_t *bwa_idx_load(const char *hint, int which, int use_mmap)
 {
-	return bwa_idx_load_from_disk(hint, which);
+	return bwa_idx_load_from_disk(hint, which, use_mmap);
 }
 
 void bwa_idx_destroy(bwaidx_t *idx)

--- a/bwa.c
+++ b/bwa.c
@@ -245,7 +245,7 @@ bwt_t *bwa_idx_load_bwt(const char *hint, int use_mmap)
 	strcat(strcpy(tmp, prefix), ".bwt"); // FM-index
 	bwt = bwt_restore_bwt(tmp, use_mmap);
 	strcat(strcpy(tmp, prefix), ".sa");  // partial suffix array (SA)
-	bwt_restore_sa(tmp, bwt);
+	bwt_restore_sa(tmp, bwt, use_mmap);
 	free(tmp); free(prefix);
 	return bwt;
 }

--- a/bwa.h
+++ b/bwa.h
@@ -42,11 +42,11 @@ extern "C" {
 	uint32_t *bwa_gen_cigar2(const int8_t mat[25], int o_del, int e_del, int o_ins, int e_ins, int w_, int64_t l_pac, const uint8_t *pac, int l_query, uint8_t *query, int64_t rb, int64_t re, int *score, int *n_cigar, int *NM);
 
 	char *bwa_idx_infer_prefix(const char *hint);
-	bwt_t *bwa_idx_load_bwt(const char *hint);
+	bwt_t *bwa_idx_load_bwt(const char *hint, int use_mmap);
 
 	bwaidx_t *bwa_idx_load_from_shm(const char *hint);
-	bwaidx_t *bwa_idx_load_from_disk(const char *hint, int which);
-	bwaidx_t *bwa_idx_load(const char *hint, int which);
+	bwaidx_t *bwa_idx_load_from_disk(const char *hint, int which, int use_mmap);
+	bwaidx_t *bwa_idx_load(const char *hint, int which, int use_mmap);
 	void bwa_idx_destroy(bwaidx_t *idx);
 	int bwa_idx2mem(bwaidx_t *idx);
 	int bwa_mem2idx(int64_t l_mem, uint8_t *mem, bwaidx_t *idx);

--- a/bwa.h
+++ b/bwa.h
@@ -20,6 +20,8 @@ typedef struct {
 	int    is_shm;
 	int64_t l_mem;
 	uint8_t  *mem;
+
+	void     *pac_mmap; // ptr to memory-mapped pac file (if mmap is being used)
 } bwaidx_t;
 
 typedef struct {

--- a/bwamem.h
+++ b/bwamem.h
@@ -54,6 +54,7 @@ typedef struct {
 	int max_matesw;         // perform maximally max_matesw rounds of mate-SW for each end
 	int max_XA_hits, max_XA_hits_alt; // if there are max_hits or fewer, output them all
 	int8_t mat[25];         // scoring matrix; mat[0] == 0 if unset
+	int use_mmap;           // use mmap to access index files
 } mem_opt_t;
 
 typedef struct {

--- a/bwape.c
+++ b/bwape.c
@@ -272,7 +272,7 @@ int bwa_cal_pac_pos_pe(const bntseq_t *bns, const char *prefix, bwt_t *const _bw
 
 	if (_bwt == 0) { // load forward SA
 		strcpy(str, prefix); strcat(str, ".bwt");  bwt = bwt_restore_bwt(str, 0);
-		strcpy(str, prefix); strcat(str, ".sa"); bwt_restore_sa(str, bwt);
+		strcpy(str, prefix); strcat(str, ".sa"); bwt_restore_sa(str, bwt, 0);
 	} else bwt = _bwt;
 
 	// SE
@@ -662,7 +662,7 @@ void bwa_sai2sam_pe_core(const char *prefix, char *const fn_sa[2], char *const f
 	{ // for Illumina alignment only
 		if (popt->is_preload) {
 			strcpy(str, prefix); strcat(str, ".bwt");  bwt = bwt_restore_bwt(str, 0);
-			strcpy(str, prefix); strcat(str, ".sa"); bwt_restore_sa(str, bwt);
+			strcpy(str, prefix); strcat(str, ".sa"); bwt_restore_sa(str, bwt, 0);
 			pac = (ubyte_t*)calloc(bns->l_pac/4+1, 1);
 			err_rewind(bns->fp_pac);
 			err_fread_noeof(pac, 1, bns->l_pac/4+1, bns->fp_pac);

--- a/bwape.c
+++ b/bwape.c
@@ -271,7 +271,7 @@ int bwa_cal_pac_pos_pe(const bntseq_t *bns, const char *prefix, bwt_t *const _bw
 	buf[1] = (aln_buf_t*)calloc(n_seqs, sizeof(aln_buf_t));
 
 	if (_bwt == 0) { // load forward SA
-		strcpy(str, prefix); strcat(str, ".bwt");  bwt = bwt_restore_bwt(str);
+		strcpy(str, prefix); strcat(str, ".bwt");  bwt = bwt_restore_bwt(str, 0);
 		strcpy(str, prefix); strcat(str, ".sa"); bwt_restore_sa(str, bwt);
 	} else bwt = _bwt;
 
@@ -661,7 +661,7 @@ void bwa_sai2sam_pe_core(const char *prefix, char *const fn_sa[2], char *const f
 	ks[1] = bwa_open_reads(opt.mode, fn_fa[1]);
 	{ // for Illumina alignment only
 		if (popt->is_preload) {
-			strcpy(str, prefix); strcat(str, ".bwt");  bwt = bwt_restore_bwt(str);
+			strcpy(str, prefix); strcat(str, ".bwt");  bwt = bwt_restore_bwt(str, 0);
 			strcpy(str, prefix); strcat(str, ".sa"); bwt_restore_sa(str, bwt);
 			pac = (ubyte_t*)calloc(bns->l_pac/4+1, 1);
 			err_rewind(bns->fp_pac);

--- a/bwase.c
+++ b/bwase.c
@@ -146,7 +146,7 @@ void bwa_cal_pac_pos(const bntseq_t *bns, const char *prefix, int n_seqs, bwa_se
 	char str[1024];
 	bwt_t *bwt;
 	// load forward SA
-	strcpy(str, prefix); strcat(str, ".bwt");  bwt = bwt_restore_bwt(str);
+	strcpy(str, prefix); strcat(str, ".bwt");  bwt = bwt_restore_bwt(str, 0);
 	strcpy(str, prefix); strcat(str, ".sa"); bwt_restore_sa(str, bwt);
 	for (i = 0; i != n_seqs; ++i) {
 		bwa_seq_t *p = &seqs[i];

--- a/bwase.c
+++ b/bwase.c
@@ -147,7 +147,7 @@ void bwa_cal_pac_pos(const bntseq_t *bns, const char *prefix, int n_seqs, bwa_se
 	bwt_t *bwt;
 	// load forward SA
 	strcpy(str, prefix); strcat(str, ".bwt");  bwt = bwt_restore_bwt(str, 0);
-	strcpy(str, prefix); strcat(str, ".sa"); bwt_restore_sa(str, bwt);
+	strcpy(str, prefix); strcat(str, ".sa"); bwt_restore_sa(str, bwt, 0);
 	for (i = 0; i != n_seqs; ++i) {
 		bwa_seq_t *p = &seqs[i];
 		bwa_cal_pac_pos_core(bns, bwt, p, max_mm, fnr);

--- a/bwashm.c
+++ b/bwashm.c
@@ -199,7 +199,7 @@ int main_shm(int argc, char *argv[])
 	if (optind < argc) {
 		if (bwa_shm_test(argv[optind]) == 0) {
 			bwaidx_t *idx;
-			idx = bwa_idx_load_from_disk(argv[optind], BWA_IDX_ALL);
+			idx = bwa_idx_load_from_disk(argv[optind], BWA_IDX_ALL, 0);
 			if (bwa_shm_stage(idx, argv[optind], tmpfn) < 0) {
 				fprintf(stderr, "[E::%s] failed to stage the index in shared memory\n", __func__);
 				ret = 1;

--- a/bwt.c
+++ b/bwt.c
@@ -602,13 +602,20 @@ void bwt_destroy(bwt_t *bwt)
 	if (bwt->bwt_mmap) {
 		fprintf(stderr, "Unmapping bwt->bwt_mmap\n");
 		bwt_unmap_file(bwt->bwt_mmap, bwt->bwt_size * sizeof(bwt->bwt[0]));
+		fprintf(stderr, "done\n");
 	}
 	else {
 		free(bwt->bwt);
 	}
 
-	bwt->bwt = NULL;
+	if (bwt->sa_mmap) {
+		fprintf(stderr, "Unmapping bwt->sa_mmap\n");
+		bwt_unmap_file(bwt->sa_mmap, (bwt->seq_len + bwt->sa_intv) / bwt->sa_intv);
+		fprintf(stderr, "done\n");
+	}
+	else {
+		free(bwt->sa);
+	}
 
-	free(bwt->sa);
 	free(bwt);
 }

--- a/bwt.c
+++ b/bwt.c
@@ -43,7 +43,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-//#include <unistd.h>
+#include <errno.h>
 
 void bwt_gen_cnt_table(bwt_t *bwt)
 {

--- a/bwt.c
+++ b/bwt.c
@@ -429,7 +429,6 @@ void* bwt_ro_mmap_file(const char *fn, size_t size) {
 	}
 	fprintf(stderr, "File %s locked in memory\n", fn);
 	close(fd);
-
 	// MADV_WILLNEED:  Expect access in the near future
 	madvise(m, st_size, MADV_WILLNEED);
 	return m;

--- a/bwt.c
+++ b/bwt.c
@@ -432,6 +432,12 @@ void* bwt_ro_mmap_file(const char *fn, size_t size) {
 	return m;
 }
 
+void bwt_unmap_file(void* map, size_t map_size)
+{
+	if (munmap(map, map_size) < 0)
+		perror(__func__);
+}
+
 void bwt_dump_bwt(const char *fn, const bwt_t *bwt)
 {
 	FILE *fp;
@@ -548,14 +554,15 @@ void bwt_destroy(bwt_t *bwt)
 {
 	if (bwt == 0) return;
 
-	munlockall();
 	if (bwt->bwt_mmap) {
 		fprintf(stderr, "Unmapping bwt->bwt_mmap\n");
-		munmap(bwt->bwt_mmap, bwt->bwt_size * sizeof(bwt->bwt[0]));
+		bwt_unmap_file(bwt->bwt_mmap, bwt->bwt_size * sizeof(bwt->bwt[0]));
 	}
 	else {
 		free(bwt->bwt);
 	}
+
+	bwt->bwt = NULL;
 
 	free(bwt->sa);
 	free(bwt);

--- a/bwt.c
+++ b/bwt.c
@@ -474,7 +474,7 @@ static bwtint_t fread_fix(FILE *fp, bwtint_t size, void *a)
 	return offset;
 }
 
-void bwt_restore_sa(const char *fn, bwt_t *bwt)
+void bwt_restore_sa(const char *fn, bwt_t *bwt, int use_mmap)
 {
 	char skipped[256];
 	FILE *fp;

--- a/bwt.c
+++ b/bwt.c
@@ -416,18 +416,16 @@ void* bwt_ro_mmap_file(const char *fn, size_t size) {
 	// MAP_HUGETLB: use huge pages.  Manual says it's only supported since kernel ver. 2.6.32
 	//              and requires special system configuration.
 	// MAP_NORESERVE: don't reserve swap space
-	int map_flags = MAP_PRIVATE | MAP_POPULATE | MAP_NORESERVE;
+	// MAP_LOCKED:  Lock the pages of the mapped region into memory in the manner of mlock(2)
+	int map_flags = MAP_PRIVATE | MAP_POPULATE | MAP_NORESERVE | MAP_LOCKED;
 	fprintf(stderr, "mmapping file %s (%0.1fMB)\n", fn, ((double)st_size) / (1024*1024));
 	void* m = mmap(0, st_size, PROT_READ, map_flags, fd, 0);
 	if (m == MAP_FAILED) {
 		perror(__func__);
 		err_fatal("Failed to map %s file to memory\n", fn);
 	}
-	if (mlock(m, st_size) < 0) {
-		perror("failed to lock file in memory");
-		err_fatal("Failed lock %s file to memory\n", fn);
-	}
 	fprintf(stderr, "File %s locked in memory\n", fn);
+	close(fd);
 
 	// MADV_WILLNEED:  Expect access in the near future
 	madvise(m, st_size, MADV_WILLNEED);

--- a/bwt.h
+++ b/bwt.h
@@ -56,6 +56,7 @@ typedef struct {
 	bwtint_t n_sa;
 	bwtint_t *sa;
 	void *bwt_mmap;
+	void *sa_mmap;
 } bwt_t;
 
 typedef struct {
@@ -88,7 +89,7 @@ extern "C" {
 	void bwt_dump_sa(const char *fn, const bwt_t *bwt);
 
 	bwt_t *bwt_restore_bwt(const char *fn, int use_mmap);
-	void bwt_restore_sa(const char *fn, bwt_t *bwt);
+	void bwt_restore_sa(const char *fn, bwt_t *bwt, int use_mmap);
 
 	void bwt_destroy(bwt_t *bwt);
 

--- a/bwt.h
+++ b/bwt.h
@@ -47,7 +47,7 @@ typedef struct {
 	bwtint_t primary; // S^{-1}(0), or the primary index of BWT
 	bwtint_t L2[5]; // C(), cumulative count
 	bwtint_t seq_len; // sequence length
-	bwtint_t bwt_size; // size of bwt, about seq_len/4
+	bwtint_t bwt_size; // number of elements in bwt, about seq_len/4
 	uint32_t *bwt; // BWT
 	// occurance array, separated to two parts
 	uint32_t cnt_table[256];
@@ -55,6 +55,7 @@ typedef struct {
 	int sa_intv;
 	bwtint_t n_sa;
 	bwtint_t *sa;
+	void *bwt_mmap;
 } bwt_t;
 
 typedef struct {
@@ -86,7 +87,7 @@ extern "C" {
 	void bwt_dump_bwt(const char *fn, const bwt_t *bwt);
 	void bwt_dump_sa(const char *fn, const bwt_t *bwt);
 
-	bwt_t *bwt_restore_bwt(const char *fn);
+	bwt_t *bwt_restore_bwt(const char *fn, int use_mmap);
 	void bwt_restore_sa(const char *fn, bwt_t *bwt);
 
 	void bwt_destroy(bwt_t *bwt);

--- a/bwt.h
+++ b/bwt.h
@@ -124,6 +124,28 @@ extern "C" {
 
 	int bwt_seed_strategy1(const bwt_t *bwt, int len, const uint8_t *q, int x, int min_len, int max_intv, bwtintv_t *mem);
 
+
+	/**
+	 * mmap a file, either the entire thing or up to `size`.
+	 *
+	 * This function maps the file in private, read-only mode.  It also asks the OS
+	 * to populate the mapped region, reading the entire file into memory and locking
+	 * it there.  For the operation to work the machine has to have sufficient physical
+	 * memory.
+	 *
+	 * In case of error the function aborts.
+	 *
+	 * \param fn:  path to file to mmap.
+	 * \param size: If `size <= 0` map the entire file; else map up to `size`.
+	 * \return pointer to start of mmapped region, as returned by mmap.
+	 */
+	void* bwt_ro_mmap_file(const char *fn, size_t size);
+
+	/**
+	 * Unmap a file previously mapped with `bwt_ro_mmap_file`.
+	 */
+	void bwt_unmap_file(void* map, size_t map_size);
+
 #ifdef __cplusplus
 }
 #endif

--- a/bwtaln.c
+++ b/bwtaln.c
@@ -169,7 +169,7 @@ void bwa_aln_core(const char *prefix, const char *fn_fa, const gap_opt_t *opt)
 
 	{ // load BWT
 		char *str = (char*)calloc(strlen(prefix) + 10, 1);
-		strcpy(str, prefix); strcat(str, ".bwt");  bwt = bwt_restore_bwt(str);
+		strcpy(str, prefix); strcat(str, ".bwt");  bwt = bwt_restore_bwt(str, 0);
 		free(str);
 	}
 

--- a/bwtindex.c
+++ b/bwtindex.c
@@ -156,7 +156,7 @@ int bwa_bwtupdate(int argc, char *argv[]) // the "bwtupdate" command
 		fprintf(stderr, "Usage: bwa bwtupdate <the.bwt>\n");
 		return 1;
 	}
-	bwt = bwt_restore_bwt(argv[1]);
+	bwt = bwt_restore_bwt(argv[1], 0);
 	bwt_bwtupdate_core(bwt);
 	bwt_dump_bwt(argv[1], bwt);
 	bwt_destroy(bwt);
@@ -177,7 +177,7 @@ int bwa_bwt2sa(int argc, char *argv[]) // the "bwt2sa" command
 		fprintf(stderr, "Usage: bwa bwt2sa [-i %d] <in.bwt> <out.sa>\n", sa_intv);
 		return 1;
 	}
-	bwt = bwt_restore_bwt(argv[optind]);
+	bwt = bwt_restore_bwt(argv[optind], 0);
 	bwt_cal_sa(bwt, sa_intv);
 	bwt_dump_sa(argv[optind+1], bwt);
 	bwt_destroy(bwt);
@@ -262,7 +262,7 @@ int bwa_index(int argc, char *argv[]) // the "index" command
 		strcpy(str, prefix); strcat(str, ".bwt");
 		t = clock();
 		fprintf(stderr, "[bwa_index] Update BWT... ");
-		bwt = bwt_restore_bwt(str);
+		bwt = bwt_restore_bwt(str, 0);
 		bwt_bwtupdate_core(bwt);
 		bwt_dump_bwt(str, bwt);
 		bwt_destroy(bwt);
@@ -282,7 +282,7 @@ int bwa_index(int argc, char *argv[]) // the "index" command
 		strcpy(str3, prefix); strcat(str3, ".sa");
 		t = clock();
 		fprintf(stderr, "[bwa_index] Construct SA from BWT and Occ... ");
-		bwt = bwt_restore_bwt(str);
+		bwt = bwt_restore_bwt(str, 0);
 		bwt_cal_sa(bwt, 32);
 		bwt_dump_sa(str3, bwt);
 		bwt_destroy(bwt);

--- a/bwtsw2_main.c
+++ b/bwtsw2_main.c
@@ -80,7 +80,7 @@ int bwa_bwtsw2(int argc, char *argv[])
 	opt->t *= opt->a;
 	opt->coef *= opt->a;
 
-	if ((idx = bwa_idx_load(argv[optind], BWA_IDX_BWT|BWA_IDX_BNS)) == 0) return 1;
+	if ((idx = bwa_idx_load(argv[optind], BWA_IDX_BWT|BWA_IDX_BNS, 0)) == 0) return 1;
 	bsw2_aln(opt, idx->bns, idx->bwt, argv[optind+1], optind+2 < argc? argv[optind+2] : 0);
 	bwa_idx_destroy(idx);
 	free(opt);

--- a/fastmap.c
+++ b/fastmap.c
@@ -130,7 +130,7 @@ int main_mem(int argc, char *argv[])
 
 	aux.opt = opt = mem_opt_init();
 	memset(&opt0, 0, sizeof(mem_opt_t));
-	while ((c = getopt(argc, argv, "1epaFMCSPVYjk:c:v:s:r:t:R:A:B:O:E:U:w:L:d:T:Q:D:m:I:N:W:x:G:h:y:K:X:H:z:")) >= 0) {
+	while ((c = getopt(argc, argv, "1epaFMCSPVYjk:c:v:s:r:t:R:A:B:O:E:U:w:L:d:T:Q:D:m:I:N:W:x:G:h:y:K:X:H:z")) >= 0) {
 		if (c == 'k') opt->min_seed_len = atoi(optarg), opt0.min_seed_len = 1;
 		else if (c == '1') no_mt_io = 1;
 		else if (c == 'x') mode = optarg;
@@ -330,7 +330,8 @@ int main_mem(int argc, char *argv[])
 	} else update_a(opt, &opt0);
 	bwa_fill_scmat(opt->a, opt->b, opt->mat);
 
-	aux.idx = bwa_idx_load_from_shm(argv[optind]);
+	if (!opt->use_mmap)
+		aux.idx = bwa_idx_load_from_shm(argv[optind]);
 	if (aux.idx == 0) {
 		if ((aux.idx = bwa_idx_load(argv[optind], BWA_IDX_ALL, opt->use_mmap)) == 0) return 1; // FIXME: memory leak
 	} else if (bwa_verbose >= 3)

--- a/fastmap.c
+++ b/fastmap.c
@@ -130,10 +130,11 @@ int main_mem(int argc, char *argv[])
 
 	aux.opt = opt = mem_opt_init();
 	memset(&opt0, 0, sizeof(mem_opt_t));
-	while ((c = getopt(argc, argv, "1epaFMCSPVYjk:c:v:s:r:t:R:A:B:O:E:U:w:L:d:T:Q:D:m:I:N:W:x:G:h:y:K:X:H:")) >= 0) {
+	while ((c = getopt(argc, argv, "1epaFMCSPVYjk:c:v:s:r:t:R:A:B:O:E:U:w:L:d:T:Q:D:m:I:N:W:x:G:h:y:K:X:H:z:")) >= 0) {
 		if (c == 'k') opt->min_seed_len = atoi(optarg), opt0.min_seed_len = 1;
 		else if (c == '1') no_mt_io = 1;
 		else if (c == 'x') mode = optarg;
+		else if (c == 'z') opt->use_mmap = 1;
 		else if (c == 'w') opt->w = atoi(optarg), opt0.w = 1;
 		else if (c == 'A') opt->a = atoi(optarg), opt0.a = 1;
 		else if (c == 'B') opt->b = atoi(optarg), opt0.b = 1;
@@ -282,6 +283,7 @@ int main_mem(int argc, char *argv[])
 		fprintf(stderr, "                     specify the mean, standard deviation (10%% of the mean if absent), max\n");
 		fprintf(stderr, "                     (4 sigma from the mean if absent) and min of the insert size distribution.\n");
 		fprintf(stderr, "                     FR orientation only. [inferred]\n");
+		fprintf(stderr, "       -z            Use MMAP to access reference structures\n");
 		fprintf(stderr, "\n");
 		fprintf(stderr, "Note: Please read the man page for detailed description of the command line and options.\n");
 		fprintf(stderr, "\n");

--- a/fastmap.c
+++ b/fastmap.c
@@ -332,7 +332,7 @@ int main_mem(int argc, char *argv[])
 
 	aux.idx = bwa_idx_load_from_shm(argv[optind]);
 	if (aux.idx == 0) {
-		if ((aux.idx = bwa_idx_load(argv[optind], BWA_IDX_ALL)) == 0) return 1; // FIXME: memory leak
+		if ((aux.idx = bwa_idx_load(argv[optind], BWA_IDX_ALL, opt->use_mmap)) == 0) return 1; // FIXME: memory leak
 	} else if (bwa_verbose >= 3)
 		fprintf(stderr, "[M::%s] load the bwa index from shared memory\n", __func__);
 	if (ignore_alt)
@@ -413,7 +413,7 @@ int main_fastmap(int argc, char *argv[])
 
 	fp = xzopen(argv[optind + 1], "r");
 	seq = kseq_init(fp);
-	if ((idx = bwa_idx_load(argv[optind], BWA_IDX_BWT|BWA_IDX_BNS)) == 0) return 1;
+	if ((idx = bwa_idx_load(argv[optind], BWA_IDX_BWT|BWA_IDX_BNS, 0)) == 0) return 1;
 	itr = smem_itr_init(idx->bwt);
 	smem_config(itr, min_intv, max_len, max_intv);
 	while (kseq_read(seq) >= 0) {

--- a/utils.c
+++ b/utils.c
@@ -87,13 +87,19 @@ gzFile err_xzopen_core(const char *func, const char *fn, const char *mode)
 	return fp;
 }
 
+void verr_fatal(const char *header, const char *fmt, va_list args)
+{
+	fprintf(stderr, "[%s] ", header);
+	vfprintf(stderr, fmt, args);
+	fprintf(stderr, "\n");
+	exit(EXIT_FAILURE);
+}
+
 void err_fatal(const char *header, const char *fmt, ...)
 {
 	va_list args;
 	va_start(args, fmt);
-	fprintf(stderr, "[%s] ", header);
-	vfprintf(stderr, fmt, args);
-	fprintf(stderr, "\n");
+	verr_fatal(header, fmt, args);
 	va_end(args);
 	exit(EXIT_FAILURE);
 }

--- a/utils.c
+++ b/utils.c
@@ -104,6 +104,17 @@ void err_fatal(const char *header, const char *fmt, ...)
 	exit(EXIT_FAILURE);
 }
 
+void perror_fatal(const char *header, const char *fmt, ...)
+{
+	perror(header);
+
+	va_list args;
+	va_start(args, fmt);
+	verr_fatal(header, fmt, args);
+	va_end(args);
+	exit(EXIT_FAILURE);
+}
+
 void err_fatal_core(const char *header, const char *fmt, ...)
 {
 	va_list args;

--- a/utils.h
+++ b/utils.h
@@ -85,6 +85,8 @@ extern "C" {
 	int err_fclose(FILE *stream);
 	int err_gzclose(gzFile file);
 
+	void perror_fatal(const char *header, const char *fmt, ...) ATTRIBUTE((noreturn));
+
 	double cputime();
 	double realtime();
 


### PR DESCRIPTION
This pull request implements memory mapped access to (larger) reference files in `bwa mem`.  The `mmap`s are created as private (copy-on-write), read-only mode and are locked in memory.  This approach presents two main advantages over allocating space in memory and `fread`ing the data into it.

The first advantage is that the reference data in memory is automatically shared in memory by all bwa processes using it.  In fact, by memory mapping the file the reference is automatically loaded into a shared memory space.

The second advantage is that the OS will not evict the reference data from memory as soon as the process exits.  Instead, it will be kept around until the memory is needed by the system.  This means that for multiple invocations of BWA with the same reference only the first will have to wait for the reference to be loaded;  the subsequent ones will re-use the same data so they will proceed directly to aligning reads.  This of course is only true if the system isn't subject to intense memory use by other processes in the meantime.

*To enable memory-mapped reference access call `bwa mem` with the new "-z" option.*

Because we're locking the reference in memory, this approach will need more memory on the system than the standard `malloc`&`fread` strategy; if the system can't comfortably fit the entire reference in memory the OS will refuse to map the file to memory.  In that case `bwa mem` will exit with an error message.

### Comparison to SHM

I originally wrote this code against version 0.7.8, then got sidetracked before I managed to put together the pull request.  I see that in the meantime I see that there's been some work towards using POSIX shared memory with the a similar objective in mind (sharing references in memory across multiple processes).

While both strategies manage to avoid loading multiple copies of the same reference in memory, I would argue that the one presented in this pull request should be preferred -- or at least co-exist -- especially for its simplicity.  A user need not do anything special to take advantage of the feature other than passing the "-z" option, while using SHM objects requires that the user pre-load the references with `bwa shm` before running `bwa mem`, and that he remember to delete them afterwards to free the resources on the system.

Explicitly having to create a delete the shared reference is also problematic and less effective for anyone launching parallel alignment jobs, perhaps through a batch queueing system, where the nodes where the `bwa` instances will end up running are not easily predicted.  In such a scenario, an alignment task should properly clean up after itself after finishing, but in doing so it may be trying to delete the shared memory object that is being used by other concurrent bwa jobs (not so bad; it should stick around until the last process releases it).  Moreover, by deleting the shared memory object when it finishes, subsequent alignment runs using the same reference will not find it in memory and thus will not be able to benefit from caching effects; they will instead have to spend time reloading it.

### Testing

I'm not sure whether there's an official test suite for contributions.  I tested by mapping 200k pairs to the human reference with both SHM and `-z` memory mapping.  I compared output by md5 checksum, after removing the `@PG` line and got identical results.
