### PR TITLE
use more portable /usr/bin/env perl for scripts

### DIFF
--- a/qualfa2fq.pl
+++ b/qualfa2fq.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/xa2multi.pl
+++ b/xa2multi.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 
 use strict;
 use warnings;


### PR DESCRIPTION
This is useful, e.g. if your perl is not installed in `/usr/bin` or you want to give a specific perl precendence over the one installed in `/usr/bin`. The `-w` is not needed since there is also `use warnings;` in these scripts.