### PR TITLE
Fixed typo in secondary alignment flag

### DIFF
--- a/bwamem.c
+++ b/bwamem.c
@@ -1001,7 +1001,7 @@ void mem_reg2sam(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac, 
 		q->flag |= extra_flag; // flag secondary
 		if (p->secondary >= 0) q->sub = -1; // don't output sub-optimal score
 		if (l && p->secondary < 0) // if supplementary
-			q->flag |= (opt->flag&MEM_F_NO_MULTI)? 0x10000 : 0x800;
+			q->flag |= (opt->flag&MEM_F_NO_MULTI)? 0x100 : 0x800;
 		if (l && !p->is_alt && q->mapq > aa.a[0].mapq) q->mapq = aa.a[0].mapq;
 		++l;
 	}


### PR DESCRIPTION
I think there is a typo in the flag bit code: 0x10000 (not a SAM flag) was intended to be 0x100 (secondary alignment).  This only applies when the -M flag is used.  As a consequence of this bug, I think that supplementary alignments are not being flagged, and so can't be filtered out in downstream code.  That said, I'm finding the logic in this section quite confusing, so I could have it all wrong.