### PR TITLE
Add -s parameter to bwa aln, to specify seed starting position.

### DIFF
--- a/bwa.1
+++ b/bwa.1
@@ -369,7 +369,10 @@ Disallow an indel within INT bp towards the ends [5]
 .BI -l \ INT
 Take the first INT subsequence as seed. If INT is larger than the query
 sequence, seeding will be disabled. For long reads, this option is
-typically ranged from 25 to 35 for `-k 2'. [inf]
+typically ranged from 25 to 35 for `-k 2'. [32]
+.TP
+.BI -s \ INT
+Start the seed after position INT. [0]
 .TP
 .BI -k \ INT
 Maximum edit distance in the seed [2]

--- a/bwape.c
+++ b/bwape.c
@@ -624,7 +624,8 @@ ubyte_t *bwa_paired_sw(const bntseq_t *bns, const ubyte_t *_pacseq, int n_seqs, 
 void bwa_sai2sam_pe_core(const char *prefix, char *const fn_sa[2], char *const fn_fa[2], pe_opt_t *popt, const char *rg_line)
 {
 	extern bwa_seqio_t *bwa_open_reads(int mode, const char *fn_fa);
-	int i, j, n_seqs, tot_seqs = 0;
+	int i, j, n_seqs;
+	uint64_t tot_seqs = 0;
 	bwa_seq_t *seqs[2];
 	bwa_seqio_t *ks[2];
 	clock_t t;
@@ -711,7 +712,7 @@ void bwa_sai2sam_pe_core(const char *prefix, char *const fn_sa[2], char *const f
 
 		for (j = 0; j < 2; ++j)
 			bwa_free_read_seq(n_seqs, seqs[j]);
-		fprintf(stderr, "[bwa_sai2sam_pe_core] %d sequences have been processed.\n", tot_seqs);
+		fprintf(stderr, "[bwa_sai2sam_pe_core] %ju sequences have been processed.\n", (uintmax_t)tot_seqs);
 		last_ii = ii;
 	}
 

--- a/bwase.c
+++ b/bwase.c
@@ -504,7 +504,8 @@ void bwase_initialize()
 void bwa_sai2sam_se_core(const char *prefix, const char *fn_sa, const char *fn_fa, int n_occ, const char *rg_line)
 {
 	extern bwa_seqio_t *bwa_open_reads(int mode, const char *fn_fa);
-	int i, n_seqs, tot_seqs = 0, m_aln;
+	int i, n_seqs, m_aln;
+	uint64_t tot_seqs = 0;
 	bwt_aln1_t *aln = 0;
 	bwa_seq_t *seqs;
 	bwa_seqio_t *ks;
@@ -562,7 +563,7 @@ void bwa_sai2sam_se_core(const char *prefix, const char *fn_sa, const char *fn_f
 		fprintf(stderr, "%.2f sec\n", (float)(clock() - t) / CLOCKS_PER_SEC);
 
 		bwa_free_read_seq(n_seqs, seqs);
-		fprintf(stderr, "[bwa_aln_core] %d sequences have been processed.\n", tot_seqs);
+		fprintf(stderr, "[bwa_aln_core] %ju sequences have been processed.\n", (uintmax_t)tot_seqs);
 	}
 
 	// destroy

--- a/bwtaln.c
+++ b/bwtaln.c
@@ -32,6 +32,7 @@ gap_opt_t *gap_init_opt()
 	o->indel_end_skip = 5; o->max_del_occ = 10; o->max_entries = 2000000;
 	o->mode = BWA_MODE_GAPE | BWA_MODE_COMPREAD;
 	o->seed_len = 32; o->max_seed_diff = 2;
+	o->seed_start = 0;
 	o->fnr = 0.04;
 	o->n_threads = 1;
 	o->max_top2 = 30;
@@ -109,13 +110,13 @@ void bwa_cal_sa_reg_gap(int tid, bwt_t *const bwt, int n_seqs, bwa_seq_t *seqs, 
 		}
 		bwt_cal_width(bwt, p->len, p->seq, w);
 		if (opt->fnr > 0.0) local_opt.max_diff = bwa_cal_maxdiff(p->len, BWA_AVG_ERR, opt->fnr);
-		local_opt.seed_len = opt->seed_len < p->len? opt->seed_len : 0x7fffffff;
-		if (p->len > opt->seed_len)
-			bwt_cal_width(bwt, opt->seed_len, p->seq + (p->len - opt->seed_len), seed_w);
+		local_opt.seed_len = opt->seed_len + opt->seed_start < p->len? opt->seed_len : 0x7fffffff;
+		if (p->len > opt->seed_len + opt->seed_start)
+			bwt_cal_width(bwt, opt->seed_len, p->seq + (p->len - opt->seed_len - opt->seed_start), seed_w);
 		// core function
 		for (j = 0; j < p->len; ++j) // we need to complement
 			p->seq[j] = p->seq[j] > 3? 4 : 3 - p->seq[j];
-		p->aln = bwt_match_gap(bwt, p->len, p->seq, w, p->len <= opt->seed_len? 0 : seed_w, &local_opt, &p->n_aln, stack);
+		p->aln = bwt_match_gap(bwt, p->len, p->seq, w, p->len <= opt->seed_len + opt->seed_start ? 0 : seed_w, &local_opt, &p->n_aln, stack);
 		//fprintf(stderr, "mm=%lld,ins=%lld,del=%lld,gapo=%lld\n", p->aln->n_mm, p->aln->n_ins, p->aln->n_del, p->aln->n_gapo);
 		// clean up the unused data in the record
 		free(p->name); free(p->seq); free(p->rseq); free(p->qual);
@@ -234,7 +235,7 @@ int bwa_aln(int argc, char *argv[])
 	char *prefix;
 
 	opt = gap_init_opt();
-	while ((c = getopt(argc, argv, "n:o:e:i:d:l:k:LR:m:t:NM:O:E:q:f:b012IYB:")) >= 0) {
+	while ((c = getopt(argc, argv, "n:o:e:i:d:l:s:k:LR:m:t:NM:O:E:q:f:b012IYB:")) >= 0) {
 		switch (c) {
 		case 'n':
 			if (strstr(optarg, ".")) opt->fnr = atof(optarg), opt->max_diff = -1;
@@ -247,6 +248,7 @@ int bwa_aln(int argc, char *argv[])
 		case 'E': opt->s_gape = atoi(optarg); break;
 		case 'd': opt->max_del_occ = atoi(optarg); break;
 		case 'i': opt->indel_end_skip = atoi(optarg); break;
+		case 's': opt->seed_start = atoi(optarg); break;
 		case 'l': opt->seed_len = atoi(optarg); break;
 		case 'k': opt->max_seed_diff = atoi(optarg); break;
 		case 'm': opt->max_entries = atoi(optarg); break;
@@ -281,6 +283,7 @@ int bwa_aln(int argc, char *argv[])
 		fprintf(stderr, "         -i INT    do not put an indel within INT bp towards the ends [%d]\n", opt->indel_end_skip);
 		fprintf(stderr, "         -d INT    maximum occurrences for extending a long deletion [%d]\n", opt->max_del_occ);
 		fprintf(stderr, "         -l INT    seed length [%d]\n", opt->seed_len);
+		fprintf(stderr, "         -s INT    seed start [%d]\n", opt->seed_start);
 		fprintf(stderr, "         -k INT    maximum differences in the seed [%d]\n", opt->max_seed_diff);
 		fprintf(stderr, "         -m INT    maximum entries in the queue [%d]\n", opt->max_entries);
 		fprintf(stderr, "         -t INT    number of threads [%d]\n", opt->n_threads);
@@ -289,7 +292,7 @@ int bwa_aln(int argc, char *argv[])
 		fprintf(stderr, "         -E INT    gap extension penalty [%d]\n", opt->s_gape);
 		fprintf(stderr, "         -R INT    stop searching when there are >INT equally best hits [%d]\n", opt->max_top2);
 		fprintf(stderr, "         -q INT    quality threshold for read trimming down to %dbp [%d]\n", BWA_MIN_RDLEN, opt->trim_qual);
-        fprintf(stderr, "         -f FILE   file to write output to instead of stdout\n");
+		fprintf(stderr, "         -f FILE   file to write output to instead of stdout\n");
 		fprintf(stderr, "         -B INT    length of barcode\n");
 		fprintf(stderr, "         -L        log-scaled gap penalty for long deletions\n");
 		fprintf(stderr, "         -N        non-iterative mode: search for all n-difference hits (slooow)\n");

--- a/bwtaln.c
+++ b/bwtaln.c
@@ -158,7 +158,8 @@ bwa_seqio_t *bwa_open_reads(int mode, const char *fn_fa)
 
 void bwa_aln_core(const char *prefix, const char *fn_fa, const gap_opt_t *opt)
 {
-	int i, n_seqs, tot_seqs = 0;
+	int i, n_seqs;
+	uint64_t tot_seqs = 0;
 	bwa_seq_t *seqs;
 	bwa_seqio_t *ks;
 	clock_t t;
@@ -218,7 +219,7 @@ void bwa_aln_core(const char *prefix, const char *fn_fa, const gap_opt_t *opt)
 		fprintf(stderr, "%.2f sec\n", (float)(clock() - t) / CLOCKS_PER_SEC);
 
 		bwa_free_read_seq(n_seqs, seqs);
-		fprintf(stderr, "[bwa_aln_core] %d sequences have been processed.\n", tot_seqs);
+		fprintf(stderr, "[bwa_aln_core] %ju sequences have been processed.\n", (uintmax_t)tot_seqs);
 	}
 
 	// destroy

--- a/bwtaln.h
+++ b/bwtaln.h
@@ -108,7 +108,7 @@ typedef struct {
 	int indel_end_skip, max_del_occ, max_entries;
 	float fnr;
 	int max_diff, max_gapo, max_gape;
-	int max_seed_diff, seed_len;
+	int max_seed_diff, seed_len, seed_start;
 	int n_threads;
 	int max_top2;
 	int trim_qual;

--- a/bwtgap.h
+++ b/bwtgap.h
@@ -6,7 +6,7 @@
 
 typedef struct { // recursion stack
 	u_int32_t info; // score<<21 | i
-	u_int32_t n_mm:8, n_gapo:8, n_gape:8, state:2, n_seed_mm:6;
+	u_int32_t n_mm:8, n_gapo:8, n_gape:8, state:2, n_seed_mm_ignore:6;
 	u_int32_t n_ins:16, n_del:16;
 	int last_diff_pos;
 	bwtint_t k, l; // (k,l) is the SA region of [i,n-1]


### PR DESCRIPTION
Ancient DNA exhibits a damage profile which make mismatches more likely at the 5' and 3' termini than within the middle of a read. In such a case, it makes sense to disable seeding. However there is no reason why seeding could not be started away from the 5' end.

Preliminary testing indicates that this can improve mapping sensitivity over seeding at the start of a read, and reduce running time vs. having the seed disabled. However, as expected, it cannot match the sensitivity of disabling the seed.

Also in my repository is a small change to use a 64bit integer to count the number of sequences. This merely stops the output from printing negative numbers when a large number of reads are aligned (observed when aligning all overlapping kmers of a reference, as described here: http://lh3lh3.users.sourceforge.net/snpable.shtml). If you do not like the -s parameter, you may wish to cherry pick this commit separately.
