### PR TITLE
Include 'unistd.h' to explicitly declare 'getopt'

### DIFF
--- a/maxk.c
+++ b/maxk.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <limits.h>
 #include <string.h>
+#include <unistd.h>
 #include "bwa.h"
 #include "bwamem.h"
 #include "kseq.h"


### PR DESCRIPTION
Although installation works for me on OS X El Capitan, installation was failing on Ubuntu 12.04.5 LTS and giving the following warnings/errors:

    gcc -c -g -Wall -Wno-unused-function -O2 -DHAVE_PTHREAD -DUSE_MALLOC_WRAPPERS  maxk.c -o maxk.o
    maxk.c: In function ‘main_maxk’:
    maxk.c:21:2: warning: implicit declaration of function ‘getopt’ [-Wimplicit-function-declaration]
    maxk.c:24:6: error: ‘optind’ undeclared (first use in this function)
    maxk.c:24:6: note: each undeclared identifier is reported only once for each function it appears in
    maxk.c:28:7: warning: left-hand operand of comma expression has no effect [-Wunused-value]
    maxk.c:28:7: warning: value computed is not used [-Wunused-value]
    maxk.c:28:7: warning: left-hand operand of comma expression has no effect [-Wunused-value]
    make: *** [maxk.o] Error 1

I fixed the installation problem by adding `#include <unistd.h>` to `maxk.c`, since it provides `getopt` functionality. All other `*.c` files in the repo that I looked at that use `getopt` also include `<unistd.h>`. As expected, when I remove that header from those files, installation fails just like the `maxk.c` step failed.