### PR TITLE
ensure bwa_sa2pos does not return without setting strand

### DIFF
--- a/bwape.c
+++ b/bwape.c
@@ -379,7 +379,7 @@ int bwa_cal_pac_pos_pe(const bntseq_t *bns, const char *prefix, bwt_t *const _bw
 						bwt_multi1_t *q = p[j]->multi + k;
 						q->pos = bwa_sa2pos(bns, bwt, q->pos, p[j]->len + q->ref_shift, &strand);
 						q->strand = strand;
-						if (q->pos != p[j]->pos)
+						if (q->pos != p[j]->pos && q->pos != (bwtint_t)-1)
 							p[j]->multi[n_multi++] = *q;
 					}
 					p[j]->n_multi = n_multi;

--- a/bwase.c
+++ b/bwase.c
@@ -113,6 +113,7 @@ bwtint_t bwa_sa2pos(const bntseq_t *bns, const bwt_t *bwt, bwtint_t sapos, int r
 {
 	bwtint_t pos_f;
 	int is_rev;
+	*strand = 0; // initialise strand to 0 otherwise we could return without setting it
 	pos_f = bwt_sa(bwt, sapos); // position on the forward-reverse coordinate
 	if (pos_f < bns->l_pac && bns->l_pac < pos_f + ref_len) return (bwtint_t)-1;
 	pos_f = bns_depos(bns, pos_f, &is_rev); // position on the forward strand; this may be the first base or the last base


### PR DESCRIPTION
it an alignment runs off the end of a chromosome bwa_sa2pos will return without setting strand, which can result in reads being silently reverse complemented