### PR TITLE
Fix for this error: "Failed to allocate 0 bytes at bntseq.c line 303"

### DIFF
--- a/bntseq.c
+++ b/bntseq.c
@@ -300,7 +300,7 @@ int64_t bns_fasta2bntseq(gzFile fp_fa, const char *prefix, int for_only)
 	while (kseq_read(seq) >= 0) pac = add1(seq, bns, pac, &m_pac, &m_seqs, &m_holes, &q);
 	if (!for_only) { // add the reverse complemented sequence
 		m_pac = (bns->l_pac * 2 + 3) / 4 * 4;
-		pac = realloc(pac, m_pac/4);
+		pac = realloc(pac, m_pac/4 ? m_pac/4 : 1 );
 		memset(pac + (bns->l_pac+3)/4, 0, (m_pac - (bns->l_pac+3)/4*4) / 4);
 		for (l = bns->l_pac - 1; l >= 0; --l, ++bns->l_pac)
 			_set_pac(pac, bns->l_pac, 3-_get_pac(pac, l));


### PR DESCRIPTION
when m_pac is < 4, we attempt to allocate 0 bytes and fail, so instead we allocate a 1 byte minimum.

this fixes this error:

   [bwa_index] Pack FASTA... [bns_fasta2bntseq] Failed to allocate 0 bytes at bntseq.c line 303: Success
