### PR TITLE
Minor doc fix

### DIFF
--- a/bwa.1
+++ b/bwa.1
@@ -202,7 +202,7 @@ Discard a MEM if it has more than
 .I INT
 occurence in the genome. This is an insensitive parameter. [500]
 .TP
-.BI -D \ INT
+.BI -D \ FLOAT
 Drop chains shorter than
 .I FLOAT
 fraction of the longest overlapping chain [0.5]


### PR DESCRIPTION
MAN page described `bwa mem` option `-D` variously as integer and float,
when it is in fact a float.