### PR TITLE
Fix warnings about types passed to abs() functions

### DIFF
--- a/bwa.c
+++ b/bwa.c
@@ -145,9 +145,9 @@ uint32_t *bwa_gen_cigar2(const int8_t mat[25], int o_del, int e_del, int o_ins, 
 		max_del = (int)((double)(((l_query+1)>>1) * mat[0] - o_del) / e_del + 1.);
 		max_gap = max_ins > max_del? max_ins : max_del;
 		max_gap = max_gap > 1? max_gap : 1;
-		w = (max_gap + llabs(rlen - l_query) + 1) >> 1;
+		w = (max_gap + abs((int)(rlen - l_query)) + 1) >> 1;
 		w = w < w_? w : w_;
-		min_w = llabs(rlen - l_query) + 3;
+		min_w = abs((int)(rlen - l_query)) + 3;
 		w = w > min_w? w : min_w;
 		// NW alignment
 		if (bwa_verbose >= 4) {

--- a/bwa.c
+++ b/bwa.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <zlib.h>
 #include <assert.h>
+#include <inttypes.h>
 #include "bntseq.h"
 #include "bwa.h"
 #include "ksw.h"
@@ -144,9 +145,9 @@ uint32_t *bwa_gen_cigar2(const int8_t mat[25], int o_del, int e_del, int o_ins, 
 		max_del = (int)((double)(((l_query+1)>>1) * mat[0] - o_del) / e_del + 1.);
 		max_gap = max_ins > max_del? max_ins : max_del;
 		max_gap = max_gap > 1? max_gap : 1;
-		w = (max_gap + abs(rlen - l_query) + 1) >> 1;
+		w = (max_gap + llabs(rlen - l_query) + 1) >> 1;
 		w = w < w_? w : w_;
-		min_w = abs(rlen - l_query) + 3;
+		min_w = llabs(rlen - l_query) + 3;
 		w = w > min_w? w : min_w;
 		// NW alignment
 		if (bwa_verbose >= 4) {

--- a/bwase.c
+++ b/bwase.c
@@ -179,7 +179,7 @@ bwa_cigar_t *bwa_refine_gapped_core(bwtint_t l_pac, const ubyte_t *pacseq, int l
 	assert(re <= l_pac);
 	rseq = bns_get_seq(l_pac, pacseq, rb, re, &rlen);
 	assert(re - rb == rlen);
-	ksw_global(len, seq, rlen, rseq, 5, mat, 5, 1, SW_BW > abs(rlen - len) * 1.5? SW_BW : abs(rlen - len) * 1.5, n_cigar, &cigar32);
+	ksw_global(len, seq, rlen, rseq, 5, mat, 5, 1, SW_BW > llabs(rlen - len) * 1.5? SW_BW : llabs(rlen - len) * 1.5, n_cigar, &cigar32);
 	assert(*n_cigar > 0);
 	if ((cigar32[*n_cigar - 1]&0xf) == 1) cigar32[*n_cigar - 1] = (cigar32[*n_cigar - 1]>>4<<4) | 3; // change endding ins to soft clipping
 	if ((cigar32[0]&0xf) == 1) cigar32[0] = (cigar32[0]>>4<<4) | 3; // change beginning ins to soft clipping

--- a/bwtsw2_pair.c
+++ b/bwtsw2_pair.c
@@ -236,7 +236,7 @@ void bsw2_pair(const bsw2opt_t *opt, int64_t l_pac, const uint8_t *pac, int n, b
 					double diff;
 					G[0] = hits[i]->hits[0].G + a[1].G;
 					G[1] = hits[i+1]->hits[0].G + a[0].G;
-					diff = fabs(G[0] - G[1]) / (opt->a + opt->b) / ((hits[i]->hits[0].len + a[1].len + hits[i+1]->hits[0].len + a[0].len) / 2.);
+					diff = abs(G[0] - G[1]) / (opt->a + opt->b) / ((hits[i]->hits[0].len + a[1].len + hits[i+1]->hits[0].len + a[0].len) / 2.);
 					if (diff > 0.05) a[G[0] > G[1]? 0 : 1].G = 0;
 				}
 				if (a[0].G == 0 || a[1].G == 0) { // one proper pair only


### PR DESCRIPTION
Use different versions of abs() based on the data types passed to them.

Fixes warnings when building with clang on OS X.

Warnings are similar to:

```
bwa.c:147:18: warning: absolute value function 'abs' given an argument of type
      'long long' but has parameter of type 'int' which may cause truncation of
      value [-Wabsolute-value]
                w = (max_gap + abs(rlen - l_query) + 1) >> 1;
                               ^
bwa.c:147:18: note: use function 'llabs' instead
                w = (max_gap + abs(rlen - l_query) + 1) >> 1;
                               ^~~
                               llabs
```
