### PR TITLE
Use rounding functions, instead of manual rounding

### DIFF
--- a/bwamem.c
+++ b/bwamem.c
@@ -115,7 +115,7 @@ static void mem_collect_intv(const mem_opt_t *opt, const bwt_t *bwt, int len, co
 {
 	int i, k, x = 0, old_n;
 	int start_width = 1;
-	int split_len = (int)(opt->min_seed_len * opt->split_factor + .499);
+	int split_len = lrintf(opt->min_seed_len * opt->split_factor);
 	a->mem.n = 0;
 	// first pass: find all SMEMs
 	while (x < len) {
@@ -426,8 +426,8 @@ int mem_patch_reg(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac,
 	w = w < opt->w<<2? w : opt->w<<2;
 	if (bwa_verbose >= 4) printf("* test potential hit merge with global alignment; w=%d\n", w);
 	bwa_gen_cigar2(opt->mat, opt->o_del, opt->e_del, opt->o_ins, opt->e_ins, w, bns->l_pac, pac, b->qe - a->qb, query + a->qb, a->rb, b->re, &score, 0, 0);
-	q_s = (int)((double)(b->qe - a->qb) / ((b->qe - b->qb) + (a->qe - a->qb)) * (b->score + a->score) + .499); // predicted score from query
-	r_s = (int)((double)(b->re - a->rb) / ((b->re - b->rb) + (a->re - a->rb)) * (b->score + a->score) + .499); // predicted score from ref
+	q_s = lrint((double)(b->qe - a->qb) / ((b->qe - b->qb) + (a->qe - a->qb)) * (b->score + a->score)); // predicted score from query
+	r_s = lrint((double)(b->re - a->rb) / ((b->re - b->rb) + (a->re - a->rb)) * (b->score + a->score)); // predicted score from ref
 	if (bwa_verbose >= 4) printf("* score=%d;(%d,%d)\n", score, q_s, r_s);
 	if ((double)score / (q_s > r_s? q_s : r_s) < PATCH_MIN_SC_RATIO) return 0;
 	*_w = w;
@@ -598,7 +598,7 @@ int mem_seed_sw(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac, i
 void mem_flt_chained_seeds(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac, int l_query, const uint8_t *query, int n_chn, mem_chain_t *a)
 {
 	double min_l = opt->min_chain_weight? MEM_HSP_COEF * opt->min_chain_weight : MEM_MINSC_COEF * log(l_query);
-	int i, j, k, min_HSP_score = (int)(opt->a * min_l + .499);
+	int i, j, k, min_HSP_score = lrint(opt->a * min_l);
 	if (min_l > MEM_SEEDSW_COEF * l_query) return; // don't run the following for short reads
 	for (i = 0; i < n_chn; ++i) {
 		mem_chain_t *c = &a[i];
@@ -956,15 +956,15 @@ int mem_approx_mapq_se(const mem_opt_t *opt, const mem_alnreg_t *a)
 		double tmp;
 		tmp = l < opt->mapQ_coef_len? 1. : opt->mapQ_coef_fac / log(l);
 		tmp *= identity * identity;
-		mapq = (int)(6.02 * (a->score - sub) / opt->a * tmp * tmp + .499);
+		mapq = lrint(6.02 * (a->score - sub) / opt->a * tmp * tmp);
 	} else {
-		mapq = (int)(MEM_MAPQ_COEF * (1. - (double)sub / a->score) * log(a->seedcov) + .499);
-		mapq = identity < 0.95? (int)(mapq * identity * identity + .499) : mapq;
+		mapq = lrint(MEM_MAPQ_COEF * (1. - (double)sub / a->score) * log(a->seedcov));
+		mapq = identity < 0.95? lrint(mapq * identity * identity) : mapq;
 	}
-	if (a->sub_n > 0) mapq -= (int)(4.343 * log(a->sub_n+1) + .499);
+	if (a->sub_n > 0) mapq -= lrint(4.343 * log(a->sub_n+1));
 	if (mapq > 60) mapq = 60;
 	if (mapq < 0) mapq = 0;
-	mapq = (int)(mapq * (1. - a->frac_rep) + .499);
+	mapq = lrint(mapq * (1. - a->frac_rep));
 	return mapq;
 }
 

--- a/bwtsw2_aux.c
+++ b/bwtsw2_aux.c
@@ -423,7 +423,7 @@ static void write_aux(const bsw2opt_t *opt, const bntseq_t *bns, int qlen, uint8
 			subo = p->G2 > opt->t? p->G2 : opt->t;
 			if (p->flag>>16 == 1 || p->flag>>16 == 2) c *= .5;
 			if (p->n_seeds < 2) c *= .2;
-			q->qual = (int)(c * (p->G - subo) * (250.0 / p->G + 0.03 / opt->a) + .499);
+			q->qual = lrint(c * (p->G - subo) * (250.0 / p->G + 0.03 / opt->a));
 			if (q->qual > 250) q->qual = 250;
 			if (q->qual < 0) q->qual = 0;
 			if (p->flag&1) q->qual = 0; // this is a random hit
@@ -547,7 +547,7 @@ static void update_opt(bsw2opt_t *dst, const bsw2opt_t *src, int qlen)
 	double ll = log(qlen);
 	int i, k;
 	*dst = *src;
-	if (dst->t < ll * dst->coef) dst->t = (int)(ll * dst->coef + .499);
+	if (dst->t < ll * dst->coef) dst->t = lrint(ll * dst->coef);
 	// set band width: the query length sets a boundary on the maximum band width
 	k = (qlen * dst->a - 2 * dst->q) / (2 * dst->r + dst->a);
 	i = (qlen * dst->a - dst->a - dst->t) / dst->r;

--- a/bwtsw2_pair.c
+++ b/bwtsw2_pair.c
@@ -45,9 +45,9 @@ bsw2pestat_t bsw2_stat(int n, bwtsw2_t **buf, kstring_t *msg, int max_ins)
 		isize[k++] = l;
 	}
 	ks_introsort_64(k, isize);
-	p25 = isize[(int)(.25 * k + .499)];
-	p50 = isize[(int)(.50 * k + .499)];
-	p75 = isize[(int)(.75 * k + .499)];
+	p25 = isize[lrint(.25 * k)];
+	p50 = isize[lrint(.50 * k)];
+	p75 = isize[lrint(.75 * k)];
 	ksprintf(msg, "[%s] infer the insert size distribution from %d high-quality pairs.\n", __func__, k);
 	if (k < 8) {
 		ksprintf(msg, "[%s] fail to infer the insert size distribution: too few good pairs.\n", __func__);
@@ -55,10 +55,10 @@ bsw2pestat_t bsw2_stat(int n, bwtsw2_t **buf, kstring_t *msg, int max_ins)
 		r.failed = 1;
 		return r;
 	}
-	tmp    = (int)(p25 - OUTLIER_BOUND * (p75 - p25) + .499);
+	tmp    = lrint(p25 - OUTLIER_BOUND * (p75 - p25));
 	r.low  = tmp > max_len? tmp : max_len;
 	if (r.low < 1) r.low = 1;
-	r.high = (int)(p75 + OUTLIER_BOUND * (p75 - p25) + .499);
+	r.high = lrint(p75 + OUTLIER_BOUND * (p75 - p25));
 	if (r.low > r.high) {
 		ksprintf(msg, "[%s] fail to infer the insert size distribution: upper bound is smaller than max read length.\n", __func__);
 		free(isize);
@@ -76,13 +76,13 @@ bsw2pestat_t bsw2_stat(int n, bwtsw2_t **buf, kstring_t *msg, int max_ins)
 			r.std += (isize[i] - r.avg) * (isize[i] - r.avg);
 	r.std = sqrt(r.std / x);
 	ksprintf(msg, "[%s] mean and std.dev: (%.2f, %.2f)\n", __func__, r.avg, r.std);
-	tmp  = (int)(p25 - 3. * (p75 - p25) + .499);
+	tmp  = lrint(p25 - 3. * (p75 - p25));
 	r.low  = tmp > max_len? tmp : max_len;
 	if (r.low < 1) r.low = 1;
-	r.high = (int)(p75 + 3. * (p75 - p25) + .499);
-	if (r.low > r.avg - MAX_STDDEV * r.std) r.low = (int)(r.avg - MAX_STDDEV * r.std + .499);
+	r.high = lrint(p75 + 3. * (p75 - p25));
+	if (r.low > r.avg - MAX_STDDEV * r.std) r.low = lrint(r.avg - MAX_STDDEV * r.std);
 	r.low = tmp > max_len? tmp : max_len;
-	if (r.high < r.avg + MAX_STDDEV * r.std) r.high = (int)(r.avg + MAX_STDDEV * r.std + .499);
+	if (r.high < r.avg + MAX_STDDEV * r.std) r.high = lrint(r.avg + MAX_STDDEV * r.std);
 	ksprintf(msg, "[%s] low and high boundaries for proper pairs: (%d, %d)\n", __func__, r.low, r.high);
 	free(isize);
 	return r;
@@ -105,13 +105,13 @@ void bsw2_pair1(const bsw2opt_t *opt, int64_t l_pac, const uint8_t *pac, const b
 	// compute the region start and end
 	a->n_seeds = 1; a->flag |= BSW2_FLAG_MATESW; // before calling this routine, *a has been cleared with memset(0); the flag is set with 1<<6/7
 	if (h->is_rev == 0) {
-		beg = (int64_t)(h->k + st->avg - EXT_STDDEV * st->std - l_mseq + .499);
+		beg = llrint(h->k + st->avg - EXT_STDDEV * st->std - l_mseq);
 		if (beg < h->k) beg = h->k;
-		end = (int64_t)(h->k + st->avg + EXT_STDDEV * st->std + .499);
+		end = llrint(h->k + st->avg + EXT_STDDEV * st->std);
 		a->is_rev = 1; a->flag |= 16;
 	} else {
-		beg = (int64_t)(h->k + h->end - h->beg - st->avg - EXT_STDDEV * st->std + .499);
-		end = (int64_t)(h->k + h->end - h->beg - st->avg + EXT_STDDEV * st->std + l_mseq + .499);
+		beg = llrint(h->k + h->end - h->beg - st->avg - EXT_STDDEV * st->std);
+		end = llrint(h->k + h->end - h->beg - st->avg + EXT_STDDEV * st->std + l_mseq);
 		if (end > h->k + (h->end - h->beg)) end = h->k + (h->end - h->beg);
 		a->is_rev = 0;
 	}

--- a/fastmap.c
+++ b/fastmap.c
@@ -213,13 +213,13 @@ int main_mem(int argc, char *argv[])
 			pes[1].std = pes[1].avg * .1;
 			if (*p != 0 && ispunct(*p) && isdigit(p[1]))
 				pes[1].std = strtod(p+1, &p);
-			pes[1].high = (int)(pes[1].avg + 4. * pes[1].std + .499);
-			pes[1].low  = (int)(pes[1].avg - 4. * pes[1].std + .499);
+			pes[1].high = lrint(pes[1].avg + 4. * pes[1].std);
+			pes[1].low  = lrint(pes[1].avg - 4. * pes[1].std);
 			if (pes[1].low < 1) pes[1].low = 1;
 			if (*p != 0 && ispunct(*p) && isdigit(p[1]))
-				pes[1].high = (int)(strtod(p+1, &p) + .499);
+				pes[1].high = lrint(strtod(p+1, &p));
 			if (*p != 0 && ispunct(*p) && isdigit(p[1]))
-				pes[1].low  = (int)(strtod(p+1, &p) + .499);
+				pes[1].low  = lrint(strtod(p+1, &p));
 			if (bwa_verbose >= 3)
 				fprintf(stderr, "[M::%s] mean insert size: %.3f, stddev: %.3f, max: %d, min: %d\n",
 						__func__, pes[1].avg, pes[1].std, pes[1].high, pes[1].low);


### PR DESCRIPTION
Use C99 rounding function for floating point to integer conversion (where rounding is involved).

In my opinion, using `lrint()` / `llrint()` is the clearest and most concise way to round / perform type conversion, as happens many places in BWA. Additionally, performance may be improved over the current method when using the ```-ffast-math` compiler flag.

Using `lrint()` / `llrint()` instead of straight math `(int)(x + 0.499)` means that a call to a library function is necessary. This call may be expensive, and definitely performs worse than the rounding method used currently, since it has to take care of setting `errno`, etc. However, compiling with `-ffast-math`, we can avoid this extra work, and we end up with a single instruction used for rounding and type conversion.

Here's a comparison of the different rounding methods that I observed, along with their compiled assembly. https://godbolt.org/g/F51HPp
