### PR TITLE
Missing includes for integral types

### DIFF
--- a/bwt_lite.c
+++ b/bwt_lite.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include <sys/types.h>
 #include "bwt_lite.h"
 
 #ifdef USE_MALLOC_WRAPPERS

--- a/bwtaln.c
+++ b/bwtaln.c
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <time.h>
 #include <stdint.h>
+#include <sys/types.h>
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/bwtgap.c
+++ b/bwtgap.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/types.h>
 #include "bwtgap.h"
 #include "bwtaln.h"
 

--- a/kthread.c
+++ b/kthread.c
@@ -1,5 +1,6 @@
 #include <pthread.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <limits.h>
 
 /************


### PR DESCRIPTION
Hi,

I had problems compiling bwa on Alpine Linux. Apparently, few includes for integral types (e.g., `u_int32_t`) were missing. 

Hope this helps.
ciao.
