### PR TITLE
aln: set mapQ = 0 when flagged UNMAP due to alignment bridging two adjacent references

### DIFF
--- a/bwase.c
+++ b/bwase.c
@@ -399,7 +399,7 @@ void bwa_print_sam1(const bntseq_t *bns, bwa_seq_t *p, const bwa_seq_t *mate, in
 		nn = bns_cnt_ambi(bns, p->pos, j, &seqid);
 		if (p->type != BWA_TYPE_NO_MATCH && p->pos + j - bns->anns[seqid].offset > bns->anns[seqid].len) {
 			flag |= SAM_FSU; // flag UNMAP as this alignment bridges two adjacent reference sequences
-                        p->mapQ = 0;
+			p->mapQ = 0;
                 }
 
 		// update flag and print it

--- a/bwase.c
+++ b/bwase.c
@@ -397,8 +397,10 @@ void bwa_print_sam1(const bntseq_t *bns, bwa_seq_t *p, const bwa_seq_t *mate, in
 
 		// get seqid
 		nn = bns_cnt_ambi(bns, p->pos, j, &seqid);
-		if (p->type != BWA_TYPE_NO_MATCH && p->pos + j - bns->anns[seqid].offset > bns->anns[seqid].len)
+		if (p->type != BWA_TYPE_NO_MATCH && p->pos + j - bns->anns[seqid].offset > bns->anns[seqid].len) {
 			flag |= SAM_FSU; // flag UNMAP as this alignment bridges two adjacent reference sequences
+                        p->mapQ = 0;
+                }
 
 		// update flag and print it
 		if (p->strand) flag |= SAM_FSR;


### PR DESCRIPTION
Allows SAM to be sorted by picard when `VALIDATION_STRINGENCY=STRICT`

Full error, which is not encountered with the one-line patch.

```
[Wed Oct 19 17:51:49 UTC 2016] picard.sam.SortSam INPUT=/var/lib/cwl/stge353be1b-a477-4e1b-9907-683669eae84d/130919_SN590_0238_AC29TRACXX_7_stock.bam OUTPUT=130919_SN590_0238_AC29TRACXX_7_stock_sorted.bam SORT_ORDER=coordinate TMP_DIR=[.] VALIDATION_STRINGENCY=STRICT CREATE_INDEX=true    VERBOSITY=INFO QUIET=false COMPRESSION_LEVEL=5 MAX_RECORDS_IN_RAM=500000 CREATE_MD5_FILE=false GA4GH_CLIENT_SECRETS=client_secrets.json
[Wed Oct 19 17:51:49 UTC 2016] Executing as ?@45dbe164a207 on Linux 3.13.0-92-generic amd64; OpenJDK 64-Bit Server VM 1.8.0_91-8u91-b14-3ubuntu1~16.04.1-b14; Picard version: 2.6.0-SNAPSHOT
[Wed Oct 19 17:51:51 UTC 2016] picard.sam.SortSam done. Elapsed time: 0.03 minutes.
Runtime.totalMemory()=759693312
To get help, see http://broadinstitute.github.io/picard/index.html#GettingHelp
Exception in thread "main" htsjdk.samtools.SAMFormatException: SAM validation error: ERROR: Record 63188, Read name HWI-ST590:238:C29TRACXX:7:1110:11285:27781, MAPQ should be 0 for unmapped read.
    at htsjdk.samtools.SAMUtils.processValidationErrors(SAMUtils.java:441)
    at htsjdk.samtools.BAMFileReader$BAMFileIterator.advance(BAMFileReader.java:665)
    at htsjdk.samtools.BAMFileReader$BAMFileIterator.next(BAMFileReader.java:650)
    at htsjdk.samtools.BAMFileReader$BAMFileIterator.next(BAMFileReader.java:620)
    at htsjdk.samtools.SamReader$AssertingIterator.next(SamReader.java:545)
    at htsjdk.samtools.SamReader$AssertingIterator.next(SamReader.java:519)
    at picard.sam.SortSam.doWork(SortSam.java:99)
    at picard.cmdline.CommandLineProgram.instanceMain(CommandLineProgram.java:208)
    at picard.cmdline.PicardCommandLine.instanceMain(PicardCommandLine.java:95)
    at picard.cmdline.PicardCommandLine.main(PicardCommandLine.java:105)
```
