### PR TITLE
Fail to infer insert size distribution when no pairs are within boundaries (re issue 108)

### DIFF
--- a/bwtsw2_pair.c
+++ b/bwtsw2_pair.c
@@ -70,6 +70,12 @@ bsw2pestat_t bsw2_stat(int n, bwtsw2_t **buf, kstring_t *msg, int max_ins)
 	for (i = x = 0, r.avg = 0; i < k; ++i)
 		if (isize[i] >= r.low && isize[i] <= r.high)
 			r.avg += isize[i], ++x;
+	if (x == 0) {
+		ksprintf(msg, "[%s] fail to infer the insert size distribution: no pairs within boundaries.\n", __func__);
+		free(isize);
+		r.failed = 1;
+		return r;
+	}
 	r.avg /= x;
 	for (i = 0, r.std = 0; i < k; ++i)
 		if (isize[i] >= r.low && isize[i] <= r.high)


### PR DESCRIPTION
@tillea's issue #108 appears to be caused by there being no sufficiently good pairs when calculating avg and std, leading to avg=NAN std=NAN and a later malloc failure when asked to malloc an insane amount of memory.

This suggested patch returns from `bsw2_stat()` with `r.failed = 1` in this case, as in other cases of insufficient read pairs.  I am not familiar enough with the implications of “failure to infer insert size distribution” to judge whether this is the best approach.