### PR TITLE
Add separate option to not lower the MAPQ score for sup. alignments

### DIFF
--- a/bwamem.c
+++ b/bwamem.c
@@ -1026,8 +1026,8 @@ void mem_reg2sam(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac, 
 		if (p->secondary >= 0) q->sub = -1; // don't output sub-optimal score
 		if (l && p->secondary < 0) // if supplementary
 			q->flag |= (opt->flag&MEM_F_NO_MULTI)? 0x10000 : 0x800;
-		if (!(opt->flag&MEM_F_PRIMARY5) && l && !p->is_alt && q->mapq > aa.a[0].mapq)
-			q->mapq = aa.a[0].mapq; // lower mapq for supplementary mappings, unless -5 is applied
+		if (!(opt->flag&MEM_F_PRIMARY5 || opt->flag&MEM_F_NO_LOWER_Q) && l && !p->is_alt && q->mapq > aa.a[0].mapq)
+			q->mapq = aa.a[0].mapq; // lower mapq for supplementary mappings, unless -5 or -q is applied
 		++l;
 	}
 	if (aa.n == 0) { // no alignments good enough; then write an unaligned record

--- a/bwamem.h
+++ b/bwamem.h
@@ -11,15 +11,16 @@
 struct __smem_i;
 typedef struct __smem_i smem_i;
 
-#define MEM_F_PE        0x2
-#define MEM_F_NOPAIRING 0x4
-#define MEM_F_ALL       0x8
-#define MEM_F_NO_MULTI  0x10
-#define MEM_F_NO_RESCUE 0x20
-#define MEM_F_REF_HDR	0x100
-#define MEM_F_SOFTCLIP  0x200
-#define MEM_F_SMARTPE   0x400
-#define MEM_F_PRIMARY5  0x800
+#define MEM_F_PE         0x2
+#define MEM_F_NOPAIRING  0x4
+#define MEM_F_ALL        0x8
+#define MEM_F_NO_MULTI   0x10
+#define MEM_F_NO_RESCUE  0x20
+#define MEM_F_REF_HDR    0x100
+#define MEM_F_SOFTCLIP   0x200
+#define MEM_F_SMARTPE    0x400
+#define MEM_F_PRIMARY5   0x800
+#define MEM_F_NO_LOWER_Q 0x1000
 
 typedef struct {
 	int a, b;               // match score and mismatch penalty

--- a/fastmap.c
+++ b/fastmap.c
@@ -130,7 +130,7 @@ int main_mem(int argc, char *argv[])
 
 	aux.opt = opt = mem_opt_init();
 	memset(&opt0, 0, sizeof(mem_opt_t));
-	while ((c = getopt(argc, argv, "51paMCSPVYjk:c:v:s:r:t:R:A:B:O:E:U:w:L:d:T:Q:D:m:I:N:o:f:W:x:G:h:y:K:X:H:")) >= 0) {
+	while ((c = getopt(argc, argv, "51paqMCSPVYjk:c:v:s:r:t:R:A:B:O:E:U:w:L:d:T:Q:D:m:I:N:o:f:W:x:G:h:y:K:X:H:")) >= 0) {
 		if (c == 'k') opt->min_seed_len = atoi(optarg), opt0.min_seed_len = 1;
 		else if (c == '1') no_mt_io = 1;
 		else if (c == 'x') mode = optarg;
@@ -148,6 +148,7 @@ int main_mem(int argc, char *argv[])
 		else if (c == 'Y') opt->flag |= MEM_F_SOFTCLIP;
 		else if (c == 'V') opt->flag |= MEM_F_REF_HDR;
 		else if (c == '5') opt->flag |= MEM_F_PRIMARY5;
+		else if (c == 'q') opt->flag |= MEM_F_NO_LOWER_Q;
 		else if (c == 'c') opt->max_occ = atoi(optarg), opt0.max_occ = 1;
 		else if (c == 'd') opt->zdrop = atoi(optarg), opt0.zdrop = 1;
 		else if (c == 'v') bwa_verbose = atoi(optarg);
@@ -268,7 +269,7 @@ int main_mem(int argc, char *argv[])
 		fprintf(stderr, "       -H STR/FILE   insert STR to header if it starts with @; or insert lines in FILE [null]\n");
 		fprintf(stderr, "       -o FILE       sam file to output results to [stdout]\n");
 		fprintf(stderr, "       -j            treat ALT contigs as part of the primary assembly (i.e. ignore <idxbase>.alt file)\n");
-		fprintf(stderr, "       -5            for split alignment, take the alignment with the smallest coordiate as primary\n");
+		fprintf(stderr, "       -5            for split alignment, take the alignment with the smallest coordinate as primary\n");
 		fprintf(stderr, "       -K INT        process INT input bases in each batch regardless of nThreads (for reproducibility) []\n");
 		fprintf(stderr, "\n");
 		fprintf(stderr, "       -v INT        verbosity level: 1=error, 2=warning, 3=message, 4+=debugging [%d]\n", bwa_verbose);
@@ -278,6 +279,7 @@ int main_mem(int argc, char *argv[])
 		fprintf(stderr, "       -C            append FASTA/FASTQ comment to SAM output\n");
 		fprintf(stderr, "       -V            output the reference FASTA header in the XR tag\n");
 		fprintf(stderr, "       -Y            use soft clipping for supplementary alignments\n");
+		fprintf(stderr, "       -q            don't lower MAPQ for supplementary alignments\n");
 		fprintf(stderr, "       -M            mark shorter split hits as secondary\n\n");
 		fprintf(stderr, "       -I FLOAT[,FLOAT[,INT[,INT]]]\n");
 		fprintf(stderr, "                     specify the mean, standard deviation (10%% of the mean if absent), max\n");


### PR DESCRIPTION
This was already part of 340babdd671eeeb3c7bfbf2e4ad1e761ece94983 for the -5 option, which however takes the alignment with the smallest coordinate as primary, which I would like to avoid.