### PR TITLE
bwa mem: read chunk size overflows for -t > 214

### DIFF
--- a/bwa.c
+++ b/bwa.c
@@ -49,7 +49,7 @@ static inline void kseq2bseq1(const kseq_t *ks, bseq1_t *s)
 	s->l_seq = ks->seq.l;
 }
 
-bseq1_t *bseq_read(int chunk_size, int *n_, void *ks1_, void *ks2_)
+bseq1_t *bseq_read(int64_t chunk_size, int *n_, void *ks1_, void *ks2_)
 {
 	kseq_t *ks = (kseq_t*)ks1_, *ks2 = (kseq_t*)ks2_;
 	int size = 0, m, n;

--- a/bwa.h
+++ b/bwa.h
@@ -39,7 +39,7 @@ extern char bwa_rg_id[256];
 extern "C" {
 #endif
 
-	bseq1_t *bseq_read(int chunk_size, int *n_, void *ks1_, void *ks2_);
+	bseq1_t *bseq_read(int64_t chunk_size, int *n_, void *ks1_, void *ks2_);
 	void bseq_classify(int n, bseq1_t *seqs, int m[2], bseq1_t *sep[2]);
 
 	void bwa_fill_scmat(int a, int b, int8_t mat[25]);

--- a/bwamem.h
+++ b/bwamem.h
@@ -43,7 +43,7 @@ typedef struct {
 	int max_occ;            // skip a seed if its occurence is larger than this value
 	int max_chain_gap;      // do not chain seed if it is max_chain_gap-bp away from the closest seed
 	int n_threads;          // number of threads
-	int chunk_size;         // process chunk_size-bp sequences in a batch
+	int64_t chunk_size;         // process chunk_size-bp sequences in a batch
 	float mask_level;       // regard a hit as redundant if the overlap with another better hit is over mask_level times the min length of the two hits
 	float drop_ratio;       // drop a chain if its seed coverage is below drop_ratio times the seed coverage of a better chain overlapping with the small chain
 	float XA_drop_ratio;    // when counting hits for the XA tag, ignore alignments with score < XA_drop_ratio * max_score; only effective for the XA tag

--- a/fastmap.c
+++ b/fastmap.c
@@ -25,7 +25,8 @@ typedef struct {
 	mem_opt_t *opt;
 	mem_pestat_t *pes0;
 	int64_t n_processed;
-	int copy_comment, actual_chunk_size;
+	int copy_comment;
+	int64_t actual_chunk_size;
 	bwaidx_t *idx;
 } ktp_aux_t;
 


### PR DESCRIPTION
When setting `-t 215` or greater, an integer overflow happens when this is multiplied by 10M in `fastmap.c` (`opt->chunk_size * opt->n_threads`).  This results in behavior where batches seem to become very small for `-t` greater than 214.  I sometimes want to set `-t` to greater than 214 on Knight's Landing systems, which is how I noticed.  These commits seem to fix it by promoting the relevant `int`s to `int64_t`s.