### PR TITLE
Bug/patch: bwa-postalt.js writes invalid output for SAM input that is an exact multiple of 65536 bytes in length

### DIFF
--- a/bwakit/bwa-postalt.js
+++ b/bwakit/bwa-postalt.js
@@ -283,7 +283,7 @@ function bwa_postalt(args)
 	// process SAM
 	var buf2 = [], hla = {};
 	file = args.length - getopt.ind >= 2? new File(args[getopt.ind+1]) : new File();
-	while (file.readline(buf) >= 0) {
+	while (file.readline(buf) > 0) {
 		var m, line = buf.toString();
 
 		if (line.charAt(0) == '@') { // print and then skip the header line


### PR DESCRIPTION
This is a really weird one: bwa-postalt will write a corrupt SAM output given SAM input files of very particular size. A reproducing test case is provided here: [bad.sam](https://drive.google.com/open?id=1uBUE1jPVCK9AEdwuQ9Tow2J0qczF5nCu); this file should be of length 1,441,792 bytes with MD5 checksum 33c28ad0404e5ea7923bef9dbdf4af15.

Specifically, if this file is run through bwa-postalt for hs38DH, a corrupt (invalid SAM) last line is output:

```
$ cat bad.sam | /static/tools/bwakit-0.7.15/k8 /static/tools/bwakit-0.7.15/bwa-postalt.js /static/references/genomes/hs38DH/hs38DH.fa.alt | tail -n 3
SRR452464.37604895	99	chr6	169307964	60	25M	=	169308090	151	TTTATTAATTAATAAAATGACCATA	@C@FFFFFHHGHHGHGJJHIJIDHJ	NM:i:0	MD:Z:25	AS:i:25	XS:i:0
SRR452464.37604895	147	chr6	169308090	60	25M	=	169307964	-151	AAAGAAGAGCCCAAAAACCAAAGCA	GIGEEGGIFIGFHHFFDDFFFFCCB	NM:i:0	MD:Z:25	AS:i:25	XS:i:21	XA:Z:chr2,+210327835,21M4S,0;
	NaN		NaN	NaN
```

This bug seems to touch some nasty corner case in buffer handling: a SAM file of even 1 byte less or more in length does not trigger the bug (regardless of whether the byte is taken from part of the `@PG` header or an extra field, or anywhere). The file is an exact multiple of 131,072 bytes (128KiB) in length, so there are many opportunities for there to be some weird exact binary boundary in play (4KiB?).

I haven't dived deeply enough to understand the full root cause, but the pull request contains a small patch that appears to fix the problem, at least for this file: changing the SAM reading bounds check from `>= 0` to `> 0` should exclude empty lines from being processed, and prevents the `\tNaN\tNaN\tNaN` line from being emitted:

```
$ cat bad.sam | /static/tools/bwakit-0.7.15/k8 ~/packages/bwa/bwakit/bwa-postalt.js /static/references/genomes/hs38DH/hs38DH.fa.alt | tail -n 3
SRR452464.37604894	163	chr7	31671527	60	25M	=	31671647	145	AGGTCCACTAGCTCTCAGCTGTCAG	@CCFFFFFHHHHHJJJJJJIJIIJJ	NM:i:0	MD:Z:25	AS:i:25	XS:i:0
SRR452464.37604895	99	chr6	169307964	60	25M	=	169308090	151	TTTATTAATTAATAAAATGACCATA	@C@FFFFFHHGHHGHGJJHIJIDHJ	NM:i:0	MD:Z:25	AS:i:25	XS:i:0
SRR452464.37604895	147	chr6	169308090	60	25M	=	169307964	-151	AAAGAAGAGCCCAAAAACCAAAGCA	GIGEEGGIFIGFHHFFDDFFFFCCB	NM:i:0	MD:Z:25	AS:i:25	XS:i:21	XA:Z:chr2,+210327835,21M4S,0;
```