### PR TITLE
bwa mem 20% speedup with vector instructions (Fixed intel-extend branch) 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ test64
 .*.swp
 Makefile.bak
 bwamem-lite
+check_avx2_support

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 CC=			gcc
 #CC=			clang --analyze
-CFLAGS=		-g -Wall -Wno-unused-function -O2
+CFLAGS=		-g -Wall -Wno-unused-function -O3
+CXXFLAGS=	-g -Wall -Wno-unused-variable -O3
 WRAP_MALLOC=-DUSE_MALLOC_WRAPPERS
 AR=			ar
 DFLAGS=		-DHAVE_PTHREAD $(WRAP_MALLOC)
 LOBJS=		utils.o kthread.o kstring.o ksw.o bwt.o bntseq.o bwa.o bwamem.o bwamem_pair.o bwamem_extra.o malloc_wrap.o \
+			intel_ext.o intel_opt/fast_extend_engine.o intel_opt/extend_vec.o \
 			QSufSort.o bwt_gen.o rope.o rle.o is.o bwtindex.o
 AOBJS=		bwashm.o bwase.o bwaseqio.o bwtgap.o bwtaln.o bamlite.o \
 			bwape.o kopen.o pemerge.o maxk.o \
@@ -19,27 +21,61 @@ ifeq ($(shell uname -s),Linux)
 	LIBS += -lrt
 endif
 
-.SUFFIXES:.c .o .cc
+COMPILER_VER:=$(shell $(CC) -dumpversion | \
+sed -e 's/\.\([0-9][0-9]\)/\1/g' \
+    -e 's/\.\([0-9]\)/0\1/g' \
+    -e 's/^[0-9]\{3,4\}$$/&00/' )
+
+AVX2_SUPPORTED:=$(shell $(CC) check_avx2_support.c -o check_avx2_support ; ./check_avx2_support | grep Yes)
+
+ifeq "$(CC)" "gcc"
+ifeq "$(AVX2_SUPPORTED)" "Yes"
+ifeq "$(shell expr $(COMPILER_VER) \>= 40901)" "1"
+$(info AVX2 Supported and GCC >= 4.9.1 detected, enabling Intel optimizations with AVX2.)
+DFLAGS += -DUSE_AVX2
+CFLAGS += -mavx -mavx2
+CXXFLAGS += -mavx -mavx2
+else
+$(info AVX2 Supported but GCC <= 4.9.1 detected, enabling Intel optimizations with SSE4.)
+CFLAGS += -msse -msse2 -mssse3 -msse4 -msse4.1 -msse4.2
+CXXFLAGS += -msse -msse2 -mssse3 -msse4 -msse4.1 -msse4.2
+endif
+else
+$(info AVX2 Not Supported, enabling Intel optimizations with SSE4.)
+CFLAGS += -msse -msse2 -mssse3 -msse4 -msse4.1 -msse4.2
+CXXFLAGS += -msse -msse2 -mssse3 -msse4 -msse4.1 -msse4.2
+endif
+endif
+
+
+.SUFFIXES:.c .o .cc .cpp
+
 
 .c.o:
 		$(CC) -c $(CFLAGS) $(DFLAGS) $(INCLUDES) $< -o $@
 
+.cpp.o:
+		$(CXX) -c $(CXXFLAGS) $(DFLAGS) $(INCLUDES) $< -o $@
+
 all:$(PROG)
 
 bwa:libbwa.a $(AOBJS) main.o
-		$(CC) $(CFLAGS) $(DFLAGS) $(AOBJS) main.o -o $@ -L. -lbwa $(LIBS)
+		$(CXX) $(CXXFLAGS) $(DFLAGS) $(AOBJS) main.o -o $@ -L. -lbwa $(LIBS)
 
 bwamem-lite:libbwa.a example.o
-		$(CC) $(CFLAGS) $(DFLAGS) example.o -o $@ -L. -lbwa $(LIBS)
+		$(CXX) $(CXXFLAGS) $(DFLAGS) example.o -o $@ -L. -lbwa $(LIBS)
 
 libbwa.a:$(LOBJS)
 		$(AR) -csru $@ $(LOBJS)
 
+ed_intrav.o:ed_intrav.cpp
+		$(CXX) -c $(CXXFLAGS) $(INCLUDES) -DSW_FILTER_AND_EXTEND -o $@ $<
+
 clean:
-		rm -f gmon.out *.o a.out $(PROG) *~ *.a
+		rm -f gmon.out *.o a.out $(PROG) *~ *.a intel_opt/*.o check_avx2_support
 
 depend:
-	( LC_ALL=C ; export LC_ALL; makedepend -Y -- $(CFLAGS) $(DFLAGS) -- *.c )
+	( LC_ALL=C ; export LC_ALL; makedepend -Y -- $(CFLAGS) $(DFLAGS) -- *.c *.cpp )
 
 # DO NOT DELETE THIS LINE -- make depend depends on it.
 
@@ -49,7 +85,7 @@ bntseq.o: bntseq.h utils.h kseq.h malloc_wrap.h khash.h
 bwa.o: bntseq.h bwa.h bwt.h ksw.h utils.h kstring.h malloc_wrap.h kvec.h
 bwa.o: kseq.h
 bwamem.o: kstring.h malloc_wrap.h bwamem.h bwt.h bntseq.h bwa.h ksw.h kvec.h
-bwamem.o: ksort.h utils.h kbtree.h
+bwamem.o: ksort.h utils.h intel_ext.h kbtree.h
 bwamem_extra.o: bwa.h bntseq.h bwt.h bwamem.h kstring.h malloc_wrap.h
 bwamem_pair.o: kstring.h malloc_wrap.h bwamem.h bwt.h bntseq.h bwa.h kvec.h
 bwamem_pair.o: utils.h ksw.h
@@ -75,6 +111,7 @@ bwtsw2_pair.o: utils.h bwt.h bntseq.h bwtsw2.h bwt_lite.h kstring.h
 bwtsw2_pair.o: malloc_wrap.h ksw.h
 example.o: bwamem.h bwt.h bntseq.h bwa.h kseq.h malloc_wrap.h
 fastmap.o: bwa.h bntseq.h bwt.h bwamem.h kvec.h malloc_wrap.h utils.h kseq.h
+fastmap.o: intel_ext.h
 is.o: malloc_wrap.h
 kopen.o: malloc_wrap.h
 kstring.o: kstring.h malloc_wrap.h
@@ -86,3 +123,8 @@ pemerge.o: ksw.h kseq.h malloc_wrap.h kstring.h bwa.h bntseq.h bwt.h utils.h
 rle.o: rle.h
 rope.o: rle.h rope.h
 utils.o: utils.h ksort.h malloc_wrap.h kseq.h
+ed_intrav.o: ed_intrav64.h ed_intrav64x2.h ed_intrav.h ed_intravED.h
+ed_intrav.o: ed_fine.h
+intel_opt/fast_extend_engine.o: intel_opt/fast_extend.h 
+intel_opt/extend_vec.o: intel_opt/extend_vec128.h intel_opt/extend_vec128x2.h intel_opt/extend_vec256.h intel_opt/extend_vec256x2.h
+intel_ext.o: intel_ext.h

--- a/bwamem.c
+++ b/bwamem.c
@@ -16,6 +16,8 @@
 #include "ksort.h"
 #include "utils.h"
 
+#include "intel_ext.h"
+
 #ifdef USE_MALLOC_WRAPPERS
 #  include "malloc_wrap.h"
 #endif
@@ -720,6 +722,11 @@ void mem_chain2aln(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac
 			tmp = s->rbeg - rmax[0];
 			rs = malloc(tmp);
 			for (i = 0; i < tmp; ++i) rs[i] = rseq[tmp - 1 - i];
+			if (opt->flag & MEM_F_FASTEXT) {
+			    a->score = intel_extend(s->qbeg, qs, tmp, rs, 5, opt->mat, opt->o_del, opt->e_del, aw[0], opt->pen_clip5, opt->zdrop, s->len * opt->a, &qle, &tle, &gtle, &gscore, &max_off[0]);
+			    if (a->score != -1)
+				goto end_left_extend;
+			}
 			for (i = 0; i < MAX_BAND_TRY; ++i) {
 				int prev = a->score;
 				aw[0] = opt->w << i;
@@ -732,6 +739,8 @@ void mem_chain2aln(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac
 				if (bwa_verbose >= 4) { printf("*** Left extension: prev_score=%d; score=%d; bandwidth=%d; max_off_diagonal_dist=%d\n", prev, a->score, aw[0], max_off[0]); fflush(stdout); }
 				if (a->score == prev || max_off[0] < (aw[0]>>1) + (aw[0]>>2)) break;
 			}
+
+end_left_extend:
 			// check whether we prefer to reach the end of the query
 			if (gscore <= 0 || gscore <= a->score - opt->pen_clip5) { // local extension
 				a->qb = s->qbeg - qle, a->rb = s->rbeg - tle;
@@ -748,6 +757,11 @@ void mem_chain2aln(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac
 			qe = s->qbeg + s->len;
 			re = s->rbeg + s->len - rmax[0];
 			assert(re >= 0);
+			if (opt->flag & MEM_F_FASTEXT) {
+				a->score = intel_extend(l_query - qe, (uint8_t*)query + qe, rmax[1] - rmax[0] - re, rseq + re, 5, opt->mat, opt->o_del, opt->e_del, aw[1], opt->pen_clip3, opt->zdrop, sc0, &qle, &tle, &gtle, &gscore, &max_off[1]);
+				if (a->score != -1)
+				    goto end_right_extend;
+			}
 			for (i = 0; i < MAX_BAND_TRY; ++i) {
 				int prev = a->score;
 				aw[1] = opt->w << i;
@@ -760,6 +774,8 @@ void mem_chain2aln(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac
 				if (bwa_verbose >= 4) { printf("*** Right extension: prev_score=%d; score=%d; bandwidth=%d; max_off_diagonal_dist=%d\n", prev, a->score, aw[1], max_off[1]); fflush(stdout); }
 				if (a->score == prev || max_off[1] < (aw[1]>>1) + (aw[1]>>2)) break;
 			}
+
+end_right_extend:
 			// similar to the above
 			if (gscore <= 0 || gscore <= a->score - opt->pen_clip3) { // local extension
 				a->qe = qe + qle, a->re = rmax[0] + re + tle;
@@ -770,7 +786,6 @@ void mem_chain2aln(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac
 			}
 		} else a->qe = l_query, a->re = s->rbeg + s->len;
 		if (bwa_verbose >= 4) printf("*** Added alignment region: [%d,%d) <=> [%ld,%ld); score=%d; {left,right}_bandwidth={%d,%d}\n", a->qb, a->qe, (long)a->rb, (long)a->re, a->score, aw[0], aw[1]);
-
 		// compute seedcov
 		for (i = 0, a->seedcov = 0; i < c->n; ++i) {
 			const mem_seed_t *t = &c->seeds[i];

--- a/bwamem.h
+++ b/bwamem.h
@@ -22,6 +22,7 @@ typedef struct __smem_i smem_i;
 #define MEM_F_PRIMARY5  0x800
 #define MEM_F_KEEP_SUPP_MAPQ 0x1000
 #define MEM_F_XB        0x2000
+#define MEM_F_FASTEXT   0x4000
 
 typedef struct {
 	int a, b;               // match score and mismatch penalty

--- a/check_avx2_support.c
+++ b/check_avx2_support.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+#include "hsw.c"
+int main() {
+    if(can_use_intel_core_4th_gen_features())
+	printf("Yes\n");
+    else
+	printf("No\n");
+    return 0;
+}

--- a/fastmap.c
+++ b/fastmap.c
@@ -12,6 +12,7 @@
 #include "utils.h"
 #include "bntseq.h"
 #include "kseq.h"
+#include "intel_ext.h"
 KSEQ_DECLARE(gzFile)
 
 extern unsigned char nst_nt4_table[256];
@@ -130,7 +131,7 @@ int main_mem(int argc, char *argv[])
 
 	aux.opt = opt = mem_opt_init();
 	memset(&opt0, 0, sizeof(mem_opt_t));
-	while ((c = getopt(argc, argv, "51qpaMCSPVYjuk:c:v:s:r:t:R:A:B:O:E:U:w:L:d:T:Q:D:m:I:N:o:f:W:x:G:h:y:K:X:H:")) >= 0) {
+	while ((c = getopt(argc, argv, "51qpafFMCSPVYjuk:c:v:s:r:t:R:A:B:O:E:U:w:L:d:T:Q:D:m:I:N:o:f:W:x:G:h:y:K:X:H:")) >= 0) {
 		if (c == 'k') opt->min_seed_len = atoi(optarg), opt0.min_seed_len = 1;
 		else if (c == '1') no_mt_io = 1;
 		else if (c == 'x') mode = optarg;
@@ -226,8 +227,10 @@ int main_mem(int argc, char *argv[])
 			if (bwa_verbose >= 3)
 				fprintf(stderr, "[M::%s] mean insert size: %.3f, stddev: %.3f, max: %d, min: %d\n",
 						__func__, pes[1].avg, pes[1].std, pes[1].high, pes[1].low);
-		}
-		else return 1;
+		} else if (c == 'F') { 
+		    opt->flag |= MEM_F_FASTEXT;
+		    intel_init();
+		} else return 1;
 	}
 
 	if (rg_line) {
@@ -253,6 +256,7 @@ int main_mem(int argc, char *argv[])
 		fprintf(stderr, "       -m INT        perform at most INT rounds of mate rescues for each read [%d]\n", opt->max_matesw);
 		fprintf(stderr, "       -S            skip mate rescue\n");
 		fprintf(stderr, "       -P            skip pairing; mate rescue performed unless -S also in use\n");
+		fprintf(stderr, "       -F            Use Intel's filter and extend \n");
 		fprintf(stderr, "\nScoring options:\n\n");
 		fprintf(stderr, "       -A INT        score for a sequence match, which scales options -TdBOELU unless overridden [%d]\n", opt->a);
 		fprintf(stderr, "       -B INT        penalty for a mismatch [%d]\n", opt->b);
@@ -269,6 +273,7 @@ int main_mem(int argc, char *argv[])
 		fprintf(stderr, "       -R STR        read group header line such as '@RG\\tID:foo\\tSM:bar' [null]\n");
 		fprintf(stderr, "       -H STR/FILE   insert STR to header if it starts with @; or insert lines in FILE [null]\n");
 		fprintf(stderr, "       -o FILE       sam file to output results to [stdout]\n");
+		fprintf(stderr, "       -f FILE       sam file to output results to [stdout]\n");
 		fprintf(stderr, "       -j            treat ALT contigs as part of the primary assembly (i.e. ignore <idxbase>.alt file)\n");
 		fprintf(stderr, "       -5            for split alignment, take the alignment with the smallest coordinate as primary\n");
 		fprintf(stderr, "       -q            don't modify mapQ of supplementary alignments\n");

--- a/hsw.c
+++ b/hsw.c
@@ -1,0 +1,80 @@
+#include <stdint.h>
+
+
+void run_cpuid(uint32_t eax, uint32_t ecx, uint32_t* abcd) {
+    uint32_t ebx, edx;
+
+    __asm__("cpuid" : "+b" (ebx), "+a" (eax), "+c" (ecx), "=d" (edx));
+    abcd[0] = eax;
+    abcd[1] = ebx;
+    abcd[2] = ecx;
+    abcd[3] = edx;
+}
+
+int check_xcr0_ymm() {
+    uint32_t xcr0;
+    __asm__("xgetbv" : "=a" (xcr0) : "c" (0) : "%edx");
+    return ((xcr0 & 6) == 6); /* checking if xmm and ymm state are enabled in XCR0 */
+}
+
+int check_4th_gen_intel_core_features() {
+    uint32_t abcd[4];
+    uint32_t fma_movbe_osxsave_mask = ((1 << 12) | (1 << 22) | (1 << 27));
+    uint32_t avx2_bmi12_mask = (1 << 5) | (1 << 3) | (1 << 8);
+    /* CPUID.(EAX=01H, ECX=0H):ECX.FMA[bit 12]==1 &&
+CPUID.(EAX=01H, ECX=0H):ECX.MOVBE[bit 22]==1 &&
+CPUID.(EAX=01H, ECX=0H):ECX.OSXSAVE[bit 27]==1 */
+    run_cpuid(1, 0, abcd);
+    if ((abcd[2] & fma_movbe_osxsave_mask) != fma_movbe_osxsave_mask)
+        return 0;
+    if (!check_xcr0_ymm())
+        return 0;
+    /* CPUID.(EAX=07H, ECX=0H):EBX.AVX2[bit 5]==1 &&
+CPUID.(EAX=07H, ECX=0H):EBX.BMI1[bit 3]==1 &&
+CPUID.(EAX=07H, ECX=0H):EBX.BMI2[bit 8]==1 */
+    run_cpuid(7, 0, abcd);
+    if ((abcd[1] & avx2_bmi12_mask) != avx2_bmi12_mask)
+        return 0;
+    /* CPUID.(EAX=80000001H):ECX.LZCNT[bit 5]==1 */
+    run_cpuid(0x80000001, 0, abcd);
+    if ((abcd[2] & (1 << 5)) == 0)
+        return 0;
+    return 1;
+}
+
+
+static int can_use_intel_core_4th_gen_features() {
+    static int the_4th_gen_features_available = -1;
+    /* test is performed once */
+    if (the_4th_gen_features_available < 0)
+        the_4th_gen_features_available = check_4th_gen_intel_core_features();
+    return the_4th_gen_features_available;
+}
+
+int is_cpuid_ecx_bit_set(int eax, int bitidx) {
+    int ecx = 0, edx = 0, ebx = 0;
+    __asm__("cpuid"
+            : "=b" (ebx),
+            "=c" (ecx),
+            "=d" (edx)
+            : "a" (eax)
+            );
+    return (((ecx >> bitidx)&1) == 1);
+}
+
+int is_sse42_supported() {
+    return is_cpuid_ecx_bit_set(1, 20);
+}
+
+/*   
+#include <stdio.h>
+int main(int argc, char** argv)
+{
+  if ( can_use_intel_core_4th_gen_features() )
+    printf("This CPU supports ISA extensions introduced in Haswell\n");
+  else
+    printf("This CPU does not support all ISA extensions introduced in Haswell\n");
+  return 1;
+}
+ */
+

--- a/intel_ext.cpp
+++ b/intel_ext.cpp
@@ -1,0 +1,105 @@
+#include <stdio.h>
+#include "intel_ext.h"
+#include "hsw.c"
+#include "utils.h"
+
+extern "C" {
+int ksw_extend(int qlen, const uint8_t *query, int tlen, const uint8_t *target, int m, const int8_t *mat, int gapo, int gape, int w, int end_bonus, int zdrop, int h0, int *qle, int *tle, int *gtle, int *gscore, int *max_off);
+
+}
+extern const int defaultCostMatrixRowCnt ;
+extern const int8_t defaultCostMatrix[];
+void fast_filter_and_extend(const uint8_t* refSeq, int refLen, const uint8_t* querySeq, int queryLen,
+			    int initScore, int endBonus, int zdrop,
+			    int& alignedQLen, int& alignedRLen, int& score,
+			    int costMatrixRowCnt=defaultCostMatrixRowCnt, 
+			    const int8_t* costMatrix=defaultCostMatrix,
+			    int gapWt=1, int gapOpenWt=6) ;
+void fast_filter(const uint8_t* refSeq, int refLen, const uint8_t* querySeq, int queryLen,
+                 int initScore, int endBonus,
+                 int& alignedQLen, int& alignedRLen, int& score, float& confidence,
+                 int mismatchWt=4, int gapWt=1, int gapOpenWt=6, int ambigWt=1) ;
+
+void init_fast_extend(bool avx2present);
+
+void intel_init()
+{
+#ifdef __x86_64
+#ifdef USE_AVX2
+    if (can_use_intel_core_4th_gen_features()) {
+	intel_extend = intel_filter_and_extend;
+	init_fast_extend(true);
+	fprintf(stderr,"Initializing Intel's filter_and_extend with AVX2\n");
+    } else if (is_sse42_supported()) {
+	err_fatal_simple("ERROR: filter_and_extend optimizations compiled with AVX2 being run without AVX2 support, please compile for current platform\n");
+    }
+#else
+    if (is_sse42_supported()) {
+	intel_extend = intel_filter_and_extend;
+	init_fast_extend(false);
+	fprintf(stderr,"Initializing Intel's filter_and_extend with SSE4.2\n");
+    } else {
+	err_fatal_simple("ERROR: filter_and_extend optimizations compiled with SSE4.2 being run without SSE4.2 support, please compile for current platform\n");
+    }
+#endif
+#else	
+    err_fatal_simple("ERROR: Intel-optimized code enabled with -f flag on a non x86-64 platform\n");
+#endif
+
+}
+
+void intel_filter(uint8_t* refSeq, int refLen, uint8_t* querySeq, int queryLen,
+		  int initScore, int endBonus)
+{
+    int alignedQLen, alignedRLen, score;
+    float confidence;
+	if (queryLen < INTEL_MIN_LEN || queryLen > INTEL_MAX_LEN) {
+		confidence = 0.0;
+		return;
+	}
+
+	int mismatchWt = 4 ;
+	int gapExtendWt = 1 ;
+	int gapOpenWt = 6 ;
+	int ambigWt = 1 ;
+	fast_filter(refSeq, refLen, querySeq, queryLen, initScore, endBonus, alignedQLen, alignedRLen, score, confidence, mismatchWt, gapExtendWt, gapOpenWt, ambigWt);
+}
+
+int intel_filter_and_extend(int qlen, const uint8_t *query, int tlen, const uint8_t *target, int m, const int8_t *mat, int gapo, int gape, int w, int end_bonus, int zdrop, int h0, int *qle, int *tle, int *gtle, int *gscore, int *max_off)
+{
+	if (qlen >= INTEL_MIN_LEN && qlen <= INTEL_MAX_LEN) {
+		int score, a = mat[0];
+		int ii = 0;
+#ifdef DEBUG0
+		for (ii=0;ii<tlen;ii++) fprintf(stderr,"%d", target[ii]);
+		fprintf(stderr, " %d ", tlen);
+		for (ii=0;ii<qlen;ii++) fprintf(stderr, "%d", query[ii]); 
+		fprintf(stderr, " %d ", qlen);
+		fprintf(stderr, "%d ", h0/a);
+		fprintf(stderr, "%d ", end_bonus/a);
+		fprintf(stderr, "%d \n", zdrop/a);
+#endif
+
+		fast_filter_and_extend(target, tlen, query, qlen, h0/a, end_bonus/a, zdrop/a, *qle, *tle, score, m, mat, gape, gapo);
+		// Convert it to the form ksw_extend uses:
+		
+		if (*qle == qlen) { // global score is chosen over local score
+		    *gscore = score; 
+		    *gtle = *tle;
+		} else {
+		    *gscore = 0;
+		    *gtle = 0;
+		}
+
+		*max_off = 0; //*gtle = *tle; *gscore = score;
+		score *= a;
+		/*
+		int score2 = score, qle2 = *qle, tle2 = *tle;
+		score = ksw_extend(qlen, query, tlen, target, m, mat, gapo, gape, w, end_bonus, zdrop, h0, qle, tle, gtle, gscore, max_off);
+		fprintf(stderr, "[%d,%d,%d] %d:%d; %d:%d; %d:%d\n", qlen, tlen, h0, score, score2, *qle, qle2, *tle, tle2);
+		*/
+		return score;
+	} else 
+	    return -1;
+}
+

--- a/intel_ext.h
+++ b/intel_ext.h
@@ -1,0 +1,23 @@
+#ifndef INTEL_EXT_H
+#define INTEL_EXT_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#define INTEL_MIN_LEN  16
+#define INTEL_MAX_LEN  255
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+	void intel_init();
+	void intel_filter(uint8_t *refSeq, int refLen, uint8_t *querySeq, int queryLen, int initScore, int endBonus);
+        int (*intel_extend)(int qlen, const uint8_t *query, int tlen, const uint8_t *target, int m, const int8_t *mat, int gapo, int gape, int w, int end_bonus, int zdrop, int h0, int *qle, int *tle, int *gtle, int *gscore, int *max_off);
+        int intel_filter_and_extend(int qlen, const uint8_t *query, int tlen, const uint8_t *target, int m, const int8_t *mat, int gapo, int gape, int w, int end_bonus, int zdrop, int h0, int *qle, int *tle, int *gtle, int *gscore, int *max_off);
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif

--- a/intel_opt/extend_vec.cpp
+++ b/intel_opt/extend_vec.cpp
@@ -1,0 +1,697 @@
+/* 
+The MIT License (MIT)
+Copyright (c) 2014 Intel Corp.
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include <iostream>
+#include <iomanip>
+#include <stdint.h>
+#include <stdlib.h>
+#include <assert.h>
+
+#include "extend_vec128.h"
+#include "extend_vec128x2.h"
+
+#ifdef USE_AVX2
+#include "extend_vec256.h"
+#include "extend_vec256x2.h"
+#endif
+
+//#define EXT_AVX2_MAIN
+//#define DEBUG
+
+using std::cout ;
+using std::endl ;
+
+const int AMBIG_BASE = 4 ;
+const int INVALID_BASE_Q = 5 ;
+const int INVALID_BASE_R = 6 ;
+
+class ExtendProblem {
+
+  const uint8_t* query_ ;
+  int queryLen_ ;
+  const uint8_t* ref_ ;
+  int refLen_ ;
+  int width_ ;
+  int initScore_ ;
+
+public:
+
+  ExtendProblem(const uint8_t* query, int queryLen, const uint8_t* ref, int refLen, 
+		int width, int initScore) :
+    query_(query), queryLen_(queryLen), ref_(ref), refLen_(refLen),
+    width_(width), initScore_(initScore) {}
+  
+  inline uint8_t getQ(int index) {
+    return (index >= queryLen_) ? INVALID_BASE_Q : query_[index] ;
+  }
+
+  inline uint8_t getR(int index) {
+    return (index >= refLen_) ? INVALID_BASE_R : ref_[index] ;
+  }
+
+} ;
+
+
+
+// To prepare the vecs that hold the next query/ref chars  
+// nextQV: ..................... [qi+2] [qi+1] [qi]
+// nextRV: [ri] [ri+1] [ri+2] .....................
+#define POPULATE_NEXTQV() {					\
+    for (int vi=0; vi < EC::MAX_VEC_LEN; ++vi) {		\
+      arr[vi] = prob.getQ(qi++) ;				\
+    }								\
+    nextQV = EC::vec_set(arr) ;					\
+  }
+
+#define POPULATE_NEXTRV() {					\
+    for (int vi = EC::MAX_VEC_LEN-1; vi >= 0; --vi) {		\
+      arr[vi] = prob.getR(ri++) ;				\
+    }								\
+    nextRV = EC::vec_set(arr) ;					\
+  }								\
+
+#define POPULATE_NEXTQV_VAR(__cnt) {				\
+    for (int vi=0; vi < __cnt; ++vi) {				\
+      arr[vi] = prob.getQ(qi++) ;				\
+    }								\
+    for (int vi=__cnt; vi < EC::MAX_VEC_LEN; ++vi) {		\
+      arr[vi] = INVALID_BASE_Q ;				\
+    }								\
+    nextQV = EC::vec_set(arr) ;					\
+  }
+
+#define POPULATE_NEXTRV_VAR(__cnt) {					\
+    for (int vi = EC::MAX_VEC_LEN-1; vi >= (EC::MAX_VEC_LEN-__cnt) ; --vi) { \
+      arr[vi] = prob.getR(ri++) ;					\
+    }									\
+    for (int vi = EC::MAX_VEC_LEN-__cnt-1; vi >= 0; --vi) {		\
+      arr[vi] = INVALID_BASE_R ;					\
+    }									\
+    nextRV = EC::vec_set(arr) ;						\
+  }									\
+
+
+#define COMPUTE_SCOREV() {						\
+    SCOREV = EC::vec_blend(MISMATCHSV, MATCHSV, EC::vec_compare_eq(RV, QV)) ; \
+    SCOREV = EC::vec_blend(SCOREV, AMBIGSV,															\
+													 EC::vec_or(EC::vec_compare_eq(RV, AMBIGBV),	\
+																			EC::vec_compare_eq(QV, AMBIGBV))) ;	\
+    SCOREV = EC::vec_blend(SCOREV, INVALIDSV,														\
+													 EC::vec_or(EC::vec_compare_eq(RV, INVALIDRBV),	\
+																			EC::vec_compare_eq(QV, INVALIDQBV))) ; \
+		}
+
+#define COMPUTE_B() {							\
+    BH = EC::vec_max(EC::vec_add(AH, DESV), EC::vec_add(AD, DOSV)) ;	\
+    BV = EC::vec_max(EC::vec_add(EC::vec_shift_left_and_insert(AV, BADV), \
+				 IESV),					\
+		     EC::vec_add(EC::vec_shift_left_and_insert(AD, BADV), \
+				 IOSV)) ;				\
+    BD = EC::vec_max(EC::vec_add(BD, SCOREV), EC::vec_max(BH, BV)) ;	\
+  }
+
+#define COMPUTE_A() {							\
+    AV = EC::vec_max(EC::vec_add(BV, IESV), EC::vec_add(BD, IOSV)) ;	\
+    AH = EC::vec_max(EC::vec_add(EC::vec_shift_right_and_insert(BH, BADV), \
+				 DESV),					\
+		     EC::vec_add(EC::vec_shift_right_and_insert(BD, BADV), \
+				 DOSV)) ;				\
+    AD = EC::vec_max(EC::vec_add(AD, SCOREV), EC::vec_max(AH, AV)) ;	\
+  }
+
+#define UPDATE_BEST_B() {						\
+    typename EC::Vec __MASK = EC::vec_compare_gt(BD, MAX_B) ;		\
+    MAX_B = EC::vec_blend(MAX_B, BD, __MASK) ;				\
+    BEST_B_DIAGV = EC::vec_blend(BEST_B_DIAGV, DIAGV, __MASK) ;		\
+  }
+
+#define UPDATE_BEST_A() {						\
+    typename EC::Vec __MASK = EC::vec_compare_gt(AD, MAX_A) ;		\
+    typename EC::Vec __MASK2 = EC::vec_compare_gt(ZEROV, AD) ;		\
+    terminate = EC::vec_test_all_ones(__MASK2, ALL_ONESV) ;		\
+    MAX_A = EC::vec_blend(MAX_A, AD, __MASK) ;				\
+    BEST_A_DIAGV = EC::vec_blend(BEST_A_DIAGV, DIAGV, __MASK) ;		\
+  }
+
+#define UPDATE_BEST_B_WITH_END_BONUS() {				\
+    typename EC::Vec __BD_EB = EC::vec_add(BD, endBonusV) ;		\
+    typename EC::Vec __MASK = EC::vec_compare_gt(__BD_EB, MAX_B) ;	\
+    MAX_B = EC::vec_blend(MAX_B, __BD_EB, __MASK) ;			\
+    BEST_B_DIAGV = EC::vec_blend(BEST_B_DIAGV, DIAGV, __MASK) ;		\
+  }
+
+#define UPDATE_BEST_A_WITH_END_BONUS() {				\
+    typename EC::Vec __AD_EB = EC::vec_add(AD, endBonusV) ;		\
+    typename EC::Vec __MASK = EC::vec_compare_gt(__AD_EB, MAX_A) ;	\
+    typename EC::Vec __MASK2 = EC::vec_compare_gt(ZEROV, __AD_EB) ;	\
+    terminate = EC::vec_test_all_ones(__MASK2, ALL_ONESV) ;		\
+    MAX_A = EC::vec_blend(MAX_A, __AD_EB, __MASK) ;			\
+    BEST_A_DIAGV = EC::vec_blend(BEST_A_DIAGV, DIAGV, __MASK) ;		\
+  }
+
+
+#define PROCESS_B() {							\
+  									\
+    /* Shift the ref vec before computing B vectors*/			\
+    RV = EC::vec_shift_left_and_insert(RV, nextRV) ;			\
+    nextRV = EC::vec_shift_left(nextRV) ;				\
+									\
+    /* Compute base score vectors (based on match/mismatch/ambig) */	\
+    COMPUTE_SCOREV() ;							\
+									\
+    /* Compute B vecs */						\
+    COMPUTE_B() ;							\
+									\
+    /* Update max scores and best indices corresponding to B vector */	\
+    UPDATE_BEST_B() ;							\
+  }
+  
+  // Repeat the corresponding operations for A
+#define PROCESS_A() {					\
+    QV = EC::vec_shift_right_and_insert(QV, nextQV) ;	\
+    nextQV = EC::vec_shift_right(nextQV) ;		\
+    COMPUTE_SCOREV() ;					\
+    COMPUTE_A() ;					\
+    UPDATE_BEST_A() ;					\
+  }
+
+#define PERFORM_SINGLE_ITER() {			\
+    PROCESS_B() ;				\
+    PROCESS_A() ;				\
+    /* Increment diag vector */			\
+    DIAGV = EC::vec_add(DIAGV, ONEV) ;		\
+  }
+
+
+#define PROCESS_B_WITH_END_BONUS() {			\
+    RV = EC::vec_shift_left_and_insert(RV, nextRV) ;	\
+    nextRV = EC::vec_shift_left(nextRV) ;		\
+    COMPUTE_SCOREV() ;					\
+    COMPUTE_B() ;					\
+    UPDATE_BEST_B_WITH_END_BONUS() ;			\
+  }
+
+#define PROCESS_A_WITH_END_BONUS() {			\
+    QV = EC::vec_shift_right_and_insert(QV, nextQV) ;	\
+    nextQV = EC::vec_shift_right(nextQV) ;		\
+    COMPUTE_SCOREV() ;					\
+    COMPUTE_A() ;					\
+    UPDATE_BEST_A_WITH_END_BONUS() ;			\
+  }
+
+#define PERFORM_SINGLE_ITER_WITH_END_BONUS() {		\
+    PROCESS_B_WITH_END_BONUS() ;			\
+    endBonusV = EC::vec_shift_right(endBonusV) ;	\
+    PROCESS_A_WITH_END_BONUS() ;			\
+    /* Increment diag vector */				\
+    DIAGV = EC::vec_add(DIAGV, ONEV) ;			\
+  }
+
+#define PRINT_VECS_FOR_DEBUG() {		\
+    cout << "DiagV: " << endl ;			\
+    EC::vec_print(DIAGV) ;			\
+    cout << "RV: " << endl ;			\
+    EC::vec_print(RV) ;				\
+    cout << "QV: " << endl ;			\
+    EC::vec_print(QV) ;				\
+    cout << "SCOREV: " << endl ;		\
+    EC::vec_print(SCOREV) ;			\
+    cout << "EndBonus: " << endl ;		\
+    EC::vec_print(endBonusV) ;			\
+    cout << "AD: " << endl ;			\
+    EC::vec_print(AD) ;				\
+    cout << "AH: " << endl ;			\
+    EC::vec_print(AH) ;				\
+    cout << "AV: " << endl ;			\
+    EC::vec_print(AV) ;				\
+    cout << "BD: " << endl ;			\
+    EC::vec_print(BD) ;				\
+    cout << "BH: " << endl ;			\
+    EC::vec_print(BH) ;				\
+    cout << "BV: " << endl ;			\
+    EC::vec_print(BV) ;				\
+    cout << "MAX_A: " << endl ;			\
+    EC::vec_print(MAX_A) ;			\
+    cout << "BEST_A: " << endl ;		\
+    EC::vec_print(BEST_A_DIAGV) ;		\
+    cout << "MAX_B: " << endl ;			\
+    EC::vec_print(MAX_B) ;			\
+    cout << "BEST_B: " << endl ;		\
+    EC::vec_print(BEST_B_DIAGV) ;		\
+  }
+
+
+template<class EC>
+int extend(int qlen, const uint8_t *query, int tlen, const uint8_t *target, int m, const int8_t *mat, int o_del, int e_del, int o_ins, int e_ins, int w, int end_bonus, int zdrop, int h0, int *_qle, int *_tle, int *_gtle, int *_gscore, int *_max_off)
+{
+
+  int diagLen = w + 1 ;
+  if (diagLen > EC::MAX_VEC_LEN) {
+    cout << "Error: This implementation cannot handle w = " << w << endl ;
+    cout << "The max w allowed = " << EC::MAX_VEC_LEN - 1 << endl ;
+    exit(0) ;
+  }
+
+  assert(m == 5) ; // 5 bases, including ambig base
+  int matchScore = mat[0] ;
+  int mismatchScore = mat[1] ;
+  int ambigScore = mat[AMBIG_BASE] ;
+
+#ifdef DEBUG
+  // Double check that the matrix is consistent
+  for (int i=0; i <= AMBIG_BASE; ++i) 
+    for (int j=0; j <= AMBIG_BASE; ++j) {
+      if (i == AMBIG_BASE || j == AMBIG_BASE)
+	assert(mat[i*m+j] == ambigScore) ;
+      else if (i == j)
+	assert(mat[i*m+j] == matchScore) ;
+      else
+	assert(mat[i*m+j] == mismatchScore) ;
+    }
+#endif
+
+  int midElt = w / 2 ; // rounded down
+
+  ExtendProblem prob(query, qlen, target, tlen, w, h0) ;
+
+  typename EC::Vec AH, AV, AD, BH, BV, BD ; // the diagonals
+  typename EC::Vec QV, RV ; // query and ref vectors
+  typename EC::Vec nextQV=EC::vec_set1(0), nextRV=EC::vec_set1(0) ; // the vectors holding the next query/ref chars
+  typename EC::Vec MAX_A ; // to keep track of the max score at each lane
+  typename EC::Vec MAX_B ; // to keep track of the max score at each lane
+  typename EC::Vec BEST_A_DIAGV ; // to keep track of the best diag index at each lane
+  typename EC::Vec BEST_B_DIAGV ; // to keep track of the best diag index at each lane
+  typename EC::Vec DIAGV ; // each lane has the same diagIndex value
+  typename EC::Vec endBonusV = EC::vec_set1(0) ;
+
+  // constant vectors
+  static const typename EC::Vec ZEROV = EC::vec_set1(0) ;
+  static const typename EC::Vec ALL_ONESV = EC::vec_set1(-1) ;
+  static const typename EC::Vec ONEV = EC::vec_set1(1) ;
+  static const typename EC::Vec BADV = EC::vec_set1(EC::BAD_SCORE) ;
+  static const typename EC::Vec DESV = EC::vec_set1(-e_del) ; // delete-extend
+  static const typename EC::Vec DOSV = EC::vec_set1(-o_del-e_del) ; // delete-open+extend
+  static const typename EC::Vec IESV = EC::vec_set1(-e_ins) ; // insert-extend
+  static const typename EC::Vec IOSV = EC::vec_set1(-o_ins-e_ins) ; // insert-open+extend
+  static const typename EC::Vec MATCHSV = EC::vec_set1(matchScore) ;
+  static const typename EC::Vec MISMATCHSV = EC::vec_set1(mismatchScore) ;
+	static const typename EC::Vec INVALIDSV = EC::vec_set1(-o_ins-o_del-e_ins-e_del) ;
+  static const typename EC::Vec AMBIGSV = EC::vec_set1(ambigScore) ;
+  static const typename EC::Vec AMBIGBV = EC::vec_set1(AMBIG_BASE) ;
+  static const typename EC::Vec INVALIDRBV = EC::vec_set1(INVALID_BASE_R) ;
+  static const typename EC::Vec INVALIDQBV = EC::vec_set1(INVALID_BASE_Q) ;
+
+  typename EC::Word arr[EC::MAX_VEC_LEN] ;
+
+  // initialize the Q vector
+  for (int vi=0; vi <= midElt; ++vi) {
+    arr[vi] = INVALID_BASE_Q ;
+  }
+
+  int qi = 0 ;
+  for (int vi=midElt+1; vi < EC::MAX_VEC_LEN; ++vi) {
+    arr[vi] = prob.getQ(qi++) ;
+  }
+  QV = EC::vec_set(arr) ;
+
+  // initialize the RV vector
+  for (int vi=EC::MAX_VEC_LEN-1; vi >= midElt; --vi) {
+    arr[vi] = INVALID_BASE_R ;
+  }
+  int ri = 0 ;
+  for (int vi=midElt-1; vi >=0; --vi) {
+    arr[vi] = prob.getR(ri++) ;
+  }
+  RV = EC::vec_set(arr) ;
+
+  // Initialize the diagonal vectors
+  AH = BADV ;
+  AV = BADV ;
+  BH = BADV ;
+  BV = BADV ;
+  BD = BADV ;
+
+  bool terminate = false ;
+
+  for (int vi=0; vi < EC::MAX_VEC_LEN; ++vi) {
+    arr[vi] = EC::BAD_SCORE ;
+  }
+  arr[midElt] = h0 ; // initial score
+  AD = EC::vec_set(arr) ;
+
+  // Initialize the max scores and best indices
+  MAX_A = AD ;
+  BEST_A_DIAGV = ZEROV ;
+  MAX_B = BD ;
+  BEST_B_DIAGV = ZEROV ;
+
+  DIAGV = ONEV ;
+
+  typename EC::Vec SCOREV ; /*temp vec to compute the match score*/  
+
+
+  // We define 3 phases as follows:
+  // Phase 1: When the last elt of vec A is above the bottom row
+  //          # of iters = qlen - (diagLen-midElt-1) - 1 (may be negative)
+  // Phase 2: When the last elt of vec A is at the bottom row
+  //          # of iters = 1 (typical) or 0 (in case the diagLen is too large compared to qlen)
+  //                     = 1 if (# of iters in phase1) >= 0 ;
+  //                       0 otherwise
+  // Phase 3: When the last elt of vec A is below the bottom row
+  //          # of iters = min(diagLen, floor((tlen-qlen)/2)+diagLen-midElt 
+  //                              The first term is selected when we have a long enough reference.
+  //                              The second term is selected when the query and ref lengths are close.
+  //                       + min(0, # of iters in phase1 +1),
+  //                              If the # of iters in phase1 is < -1, we adjust the iter cnt.
+  //                              (In a typical case, we assume phase 3 starts when the last elt
+  //                               of vec A is 1 row below the last row. If the # of iters in phase1
+  //                               is < -1, we have to adjust this accordingly.)
+  // 
+  // Another upper bound for # of iterations is for cases where tlen < qlen:
+  //       # iters <= tlen + (diagLen - midElt)
+  //       Note: The equality above happens when the last elt of vec A is to the right of last column
+  // 
+  //
+  // While running these 3 phases, we need to fill in nextQV and nextRV vectors with EC::MAX_VEC_LEN
+  // elements. So, we need to divide these phases further to refill nextQV and nextRV occasionally.
+
+  int numItersUpperBound = tlen + diagLen - midElt ; // upper bound due to target length
+
+  // Phase 1: 
+  int numItersPhase1 = std::min(numItersUpperBound, qlen - (diagLen - midElt)) ;
+  int numItersPhase3 = std::min(diagLen,(tlen-qlen)/2 + diagLen - midElt) + std::min(0, numItersPhase1+1) ;
+  if (numItersPhase1+1 >= numItersUpperBound)
+    numItersPhase3 = 0 ;
+  
+
+  int numRemainingEltsInNextQR = 0 ;
+
+  if (numItersPhase1 > 0) {
+    int numFullIters = numItersPhase1 / EC::MAX_VEC_LEN ;
+    int numPartialIters = numItersPhase1 % EC::MAX_VEC_LEN ;
+    
+
+    for (int fullIterIndex=0; fullIterIndex < numFullIters; ++fullIterIndex) {
+      POPULATE_NEXTQV() ;
+      POPULATE_NEXTRV() ;
+
+      // bvi: base vector index (indexing into nextRV and nextQV)
+      for (int bvi=0; bvi < EC::MAX_VEC_LEN; ++bvi) {
+	PERFORM_SINGLE_ITER() ;
+#ifdef DEBUG
+	PRINT_VECS_FOR_DEBUG() ;
+#endif
+	if (terminate) goto LoopEnd ;
+      }
+    }
+    POPULATE_NEXTQV() ;
+    POPULATE_NEXTRV() ; 
+
+    for (int bvi=0; bvi < numPartialIters; ++bvi) {
+      PERFORM_SINGLE_ITER() ;
+#ifdef DEBUG
+      PRINT_VECS_FOR_DEBUG() ;
+#endif
+      if (terminate) goto LoopEnd ;
+    }
+
+    numRemainingEltsInNextQR = EC::MAX_VEC_LEN - numPartialIters ;
+  }
+
+  // In phase 2 and 3, we should add the end_bonus to each score at the last row.
+  // In phase 2, the last elt of vec A is at the last row.
+  // Initialize the end bonus vec:
+  for (int vi=0; vi < EC::MAX_VEC_LEN; ++vi)
+    arr[vi] = 0 ;
+  arr[diagLen-1] = end_bonus ;
+  endBonusV = EC::vec_set(arr) ;
+
+
+  // Phase 2: 
+  if (numItersPhase1 >= 0 && numItersPhase1 < numItersUpperBound) {
+    assert(numRemainingEltsInNextQR >= 0) ;
+    if (numRemainingEltsInNextQR == 0) {
+      POPULATE_NEXTQV() ;
+      POPULATE_NEXTRV() ;
+      numRemainingEltsInNextQR = EC::MAX_VEC_LEN ;
+    }
+
+    PROCESS_B() ;
+    PROCESS_A_WITH_END_BONUS() ;    
+    DIAGV = EC::vec_add(DIAGV, ONEV) ;
+
+#ifdef DEBUG
+    PRINT_VECS_FOR_DEBUG() ;
+#endif
+    --numRemainingEltsInNextQR ;
+
+    if (terminate) goto LoopEnd ;
+  }
+
+  // Phase 3:
+  assert(numItersPhase3 <= EC::MAX_VEC_LEN) ;
+  
+  if (numItersPhase3 > 0) {
+    
+    if (numRemainingEltsInNextQR == 0) {
+      POPULATE_NEXTQV_VAR(numItersPhase3) ;
+      POPULATE_NEXTRV_VAR(numItersPhase3) ;
+      numRemainingEltsInNextQR = numItersPhase3 ;
+    }
+
+    // We may need to refill nextQV and nextRV vecs in the middle. So, divide phase3 into 2 stages.
+    int numItersPhase3a = std::min(numRemainingEltsInNextQR, numItersPhase3) ;
+    int numItersPhase3b = std::max(0, numItersPhase3 - numRemainingEltsInNextQR) ;
+
+    for (int iter=0; iter<numItersPhase3a; ++iter) {
+      PERFORM_SINGLE_ITER_WITH_END_BONUS() ;
+#ifdef DEBUG
+      PRINT_VECS_FOR_DEBUG() ;
+#endif
+      if (terminate) goto LoopEnd ;
+    }
+
+    POPULATE_NEXTQV_VAR(numItersPhase3b) ;
+    POPULATE_NEXTRV_VAR(numItersPhase3b) ;
+
+    for (int iter=0; iter<numItersPhase3b; ++iter) {
+      PERFORM_SINGLE_ITER_WITH_END_BONUS() ;
+#ifdef DEBUG
+      PRINT_VECS_FOR_DEBUG() ;
+#endif
+      if (terminate) goto LoopEnd ;
+    }
+  }
+  
+ LoopEnd:
+
+  // Compute the best score
+  typename EC::Word* arrMaxB = ((typename EC::Word*) &MAX_B) ;
+  typename EC::Word* arrMaxA = ((typename EC::Word*) &MAX_A) ;
+  typename EC::Word* arrBestBDiag = ((typename EC::Word*) &BEST_B_DIAGV) ;
+  typename EC::Word* arrBestADiag = ((typename EC::Word*) &BEST_A_DIAGV) ;
+
+  typename EC::Word maxLocalScore = h0 ;
+  typename EC::Word bestRIndex = -1 ;
+  typename EC::Word bestQIndex = -1 ;
+
+  for (int lane=0; lane < diagLen; ++lane) {
+
+    if (arrMaxA[lane] >= maxLocalScore) {
+#ifdef DEBUG
+      cout << lane << ": " << maxLocalScore << " < " << arrMaxA[lane] 
+      	   << ", d = " << arrBestADiag[lane] << endl ;
+#endif
+      int d = arrBestADiag[lane] ; // the diag index for this score
+      int currRIndex = d - 1 + midElt - lane ;
+      int currQIndex = d - 1 - midElt + lane ;
+
+      // If arrMaxA[lane] == maxLocalScore, then we favor smaller query
+      // indices to be consistent with the BWA implementation.
+      if (arrMaxA[lane] > maxLocalScore || currQIndex < bestQIndex) {
+	bestRIndex = currRIndex ;
+	bestQIndex = currQIndex ;
+	maxLocalScore = arrMaxA[lane] ;
+      }
+
+#ifdef DEBUG
+      cout << "best indices: " << bestRIndex << " " << bestQIndex << endl ;
+#endif
+    }
+
+    if (arrMaxB[lane] >= maxLocalScore) {
+
+      int d = arrBestBDiag[lane] ; // the diag index for this score
+      int currRIndex = d - 1 + midElt - lane ;
+      int currQIndex = d - 2 - midElt + lane ;
+
+      // If arrMaxB[lane] == maxLocalScore, then we favor smaller query
+      // indices to be consistent with the BWA implementation.
+      if (arrMaxB[lane] > maxLocalScore || currQIndex < bestQIndex) {
+	bestRIndex = currRIndex ;
+	bestQIndex = currQIndex ;
+	maxLocalScore = arrMaxB[lane] ;
+      }
+    }
+
+  }
+
+  // Convert it to the form ksw_extend uses:
+  int gscore = 0, lscore = 0, tle = 0, gtle = 0 ;
+  if (bestQIndex+1 == qlen) { // global score is chosen over local score
+    gscore = maxLocalScore - end_bonus ; // end_bonus was added to maxLocalScore before
+    gtle = std::min(tlen, bestRIndex + 1) ;
+    // Because of band limitations, it's possible that max score ends up beyond ref index.
+    // This can happen when tlen < queryLen and the band that overlaps with the last query
+    // row is beyond column tlen.
+  }
+  else {
+    lscore = maxLocalScore ;
+    tle = std::min(tlen, bestRIndex + 1) ;
+    // Because of band limitations, it's possible that max score ends up beyond ref index.
+    // The min operation probably is not needed in case of local alignment, but keeping it
+    // here for safety.
+  }
+
+#ifdef DEBUG
+  cout << "Results: " << gscore << " " <<  bestQIndex+1 << " " << gtle << " " << lscore << " " << tle << endl ;
+#endif
+
+  if (_qle) *_qle = bestQIndex+1 ;
+  if (_tle) *_tle = tle ;
+  if (_gtle) *_gtle = gtle ; 
+  if (_gscore) *_gscore = gscore ; 
+
+	assert(*_qle <= qlen) ;
+	assert(*_tle <= tlen) ;
+
+  return lscore ;
+}
+
+
+// wrappers
+
+int ksw_extend_sse_8(int qlen, const uint8_t *query, int tlen, const uint8_t *target, int m, const int8_t *mat, int gapo, int gape, int w, int end_bonus, int zdrop, int h0, int *qle, int *tle, int *gtle, int *gscore, int *max_off) {
+
+  return extend<EC16BitSSE>(qlen, query, tlen, target, m, mat, gapo, gape, gapo,
+			    gape, w, end_bonus, zdrop, h0, qle, tle, gtle,
+			    gscore, max_off) ;
+}
+
+int ksw_extend_sse_16(int qlen, const uint8_t *query, int tlen, const uint8_t *target, int m, const int8_t *mat, int gapo, int gape, int w, int end_bonus, int zdrop, int h0, int *qle, int *tle, int *gtle, int *gscore, int *max_off) {
+
+  return extend<EC16BitSSE_16>(qlen, query, tlen, target, m, mat, gapo, gape, gapo,
+			       gape, w, end_bonus, zdrop, h0, qle, tle, gtle,
+			       gscore, max_off) ;
+}
+
+
+#ifdef USE_AVX2
+int ksw_extend_avx2_16(int qlen, const uint8_t *query, int tlen, const uint8_t *target, int m, const int8_t *mat, int gapo, int gape, int w, int end_bonus, int zdrop, int h0, int *qle, int *tle, int *gtle, int *gscore, int *max_off) {
+
+  return extend<EC16BitAvx2>(qlen, query, tlen, target, m, mat, gapo, gape, gapo,
+			     gape, w, end_bonus, zdrop, h0, qle, tle, gtle,
+			     gscore, max_off) ;
+}
+
+
+int ksw_extend_avx2_32(int qlen, const uint8_t *query, int tlen, const uint8_t *target, int m, const int8_t *mat, int gapo, int gape, int w, int end_bonus, int zdrop, int h0, int *qle, int *tle, int *gtle, int *gscore, int *max_off) {
+
+  return extend<EC16BitAvx2_32>(qlen, query, tlen, target, m, mat, gapo, gape, gapo,
+				 gape, w, end_bonus, zdrop, h0, qle, tle, gtle,
+				 gscore, max_off) ;
+}
+
+#endif // #ifdef USE_AVX2
+
+
+
+
+#ifdef EXT_AVX2_MAIN
+
+const int costMatrixRowCnt = 5 ;
+const int8_t costMatrix[] = {
+  1, -4, -4, -4, -1,
+  -4, 1, -4, -4, -1,
+  -4, -4, 1, -4, -1,
+  -4, -4, -4, 1, -1,
+  -1, -1, -1, -1, -1 
+} ;
+
+const int gapo = 6 ;
+const int gape = 1 ; 
+
+bool test1() {
+
+  const uint8_t query[] = {2, 0, 3, 1, 2} ;
+  const uint8_t ref[] = {2, 0, 3, 1, 2} ;
+  
+
+  int qlen = 5 ;
+  int rlen = 5 ;
+  int zdrop = 0 ;
+  int h0 = 0 ;
+  int w = 1 ;
+  int endBonus = 0 ;
+  
+
+  int qle, tle, gtle, gscore ;
+
+  int localScore = 
+    extend<EC16BitAvx2> (qlen, query, rlen, ref, costMatrixRowCnt, costMatrix,
+			 gapo, gape, gapo, gape, w, endBonus, zdrop, h0,
+			 &qle, &tle, &gtle, &gscore, NULL) ;
+
+  cout << "Local score computed = " << localScore << endl ;
+  cout << "Query and ref alignment= " << qle << " and " << tle << endl ;
+
+  if (qle != qlen || tle != qlen) {
+    cout << "Error: Test 1 failed" << endl ;
+  }
+
+}
+
+bool test2() {
+
+  const uint8_t query[] = {2, 0, 3, 1, 2, 3, 1, 2, 0} ;
+  const uint8_t ref[] = {2, 4, 2, 0, 3, 1, 2, 3, 1, 2, 0} ;
+  
+
+  int qlen = 9 ;
+  int rlen = 11 ;
+  int zdrop = 0 ;
+  int h0 = 0 ;
+  int w = 15 ;
+  int endBonus = 0 ;
+
+  int qle, tle, gtle, gscore ;
+
+  int localScore = 
+    extend<EC16BitAvx2> (qlen, query, rlen, ref, costMatrixRowCnt, costMatrix,
+			 gapo, gape, gapo, gape, w, endBonus, zdrop, h0,
+			 &qle, &tle, &gtle, &gscore, NULL) ;
+
+  cout << "Local score computed = " << localScore << endl ;
+  cout << "Query and ref alignment= " << qle << " and " << tle << endl ;
+
+  if (qle != qlen || tle != rlen) {
+    cout << "Error: Test 1 failed" << endl ;
+  }
+
+}
+
+
+
+int main() {
+
+  test2() ;
+
+  return 0 ;
+}
+
+#endif // #ifdef EXT_AVX2_MAIN

--- a/intel_opt/extend_vec128.h
+++ b/intel_opt/extend_vec128.h
@@ -1,0 +1,98 @@
+/* 
+The MIT License (MIT)
+Copyright (c) 2014 Intel Corp.
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+
+#include <immintrin.h>
+
+#include <iostream>
+#include <iomanip>
+#include <stdint.h>
+#include <stdlib.h>
+#include <assert.h>
+
+using std::cout ;
+using std::endl ;
+
+class EC16BitSSE {
+  
+public:
+  
+  typedef __m128i Vec ;
+  typedef int16_t Word ;
+
+  static const int MAX_VEC_LEN = 8 ;
+  static const int BAD_SCORE = -1000 ;
+
+  
+  static inline Vec vec_set(Word* arr) {
+    return _mm_set_epi16(arr[7], arr[6], arr[5], arr[4], arr[3], arr[2], arr[1], arr[0]) ;
+  }
+
+  static inline Vec vec_set1(Word val) {
+    return _mm_set1_epi16(val) ;
+  }
+
+  static inline Vec vec_add(const Vec& v1, const Vec& v2) {
+    return _mm_add_epi16(v1, v2) ;
+  }
+
+  static inline Vec vec_or(const Vec& v1, const Vec& v2) {
+    return _mm_or_si128(v1, v2) ;
+  }
+
+  static inline Vec vec_max(const Vec& v1, const Vec& v2) {
+    return _mm_max_epi16(v1, v2) ;
+  }
+
+  static inline Vec vec_compare_eq(const Vec& v1, const Vec& v2) {
+    return _mm_cmpeq_epi16(v1, v2) ;
+  }
+
+  static inline Vec vec_compare_gt(const Vec& v1, const Vec& v2) {
+    return _mm_cmpgt_epi16(v1, v2) ;
+  }
+  
+  static inline Vec vec_blend(const Vec& vFalse, const Vec& vTrue, const Vec& mask) {
+    return _mm_blendv_epi8(vFalse, vTrue, mask) ;
+  }
+
+  static inline bool vec_test_all_ones(const Vec& v, const Vec& allOnesV) {
+    return _mm_test_all_ones(v) ;
+  }
+
+  // 0 is inserted to LSW
+  static inline __m128i vec_shift_left (const __m128i& vec) {
+    return _mm_slli_si128(vec, 2) ;
+  }
+
+  // The most significant word (MSW) in words is inserted to LSW of vec
+  static inline __m128i vec_shift_left_and_insert (const __m128i& vec, const __m128i& words) {
+    return _mm_alignr_epi8(vec, words, 14) ;
+  }
+
+  // 0 is inserted to MSW
+  static inline __m128i vec_shift_right (const __m128i& vec) {
+    return _mm_srli_si128(vec, 2) ;
+  }
+
+  // The LSW of words is inserted to the MSW of vec
+  static inline __m128i vec_shift_right_and_insert (const __m128i& vec, const __m128i& words) {
+    return _mm_alignr_epi8(words, vec, 2) ;
+  }
+
+  static void vec_print(const Vec& vec) ;
+
+} ;
+
+void EC16BitSSE::vec_print(const Vec& vec) {
+  for(int i = 7; i >= 0; i--)
+    cout << std::setw(5) << ((const int16_t*) (&vec))[i] << " " ;
+
+  cout << endl ;
+}
+

--- a/intel_opt/extend_vec128x2.h
+++ b/intel_opt/extend_vec128x2.h
@@ -1,0 +1,120 @@
+/* 
+The MIT License (MIT)
+Copyright (c) 2014 Intel Corp.
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include <immintrin.h>
+
+#include <iostream>
+#include <iomanip>
+#include <stdint.h>
+#include <stdlib.h>
+#include <assert.h>
+
+using std::cout ;
+using std::endl ;
+
+class EC16BitSSE_16 {
+  
+public:
+  
+  typedef int16_t Word ;
+
+  struct Vec {
+    __m128i v[2]; 
+    
+    Vec(){}
+    explicit Vec(__m128i v1, __m128i v0) {
+      v[1] = v1 ;
+      v[0] = v0 ;
+    }
+  } ;
+
+
+  static const int MAX_VEC_LEN = 16 ;
+  static const int BAD_SCORE = -1000 ;
+  
+  static inline Vec vec_set(Word* arr) {
+    return Vec(_mm_set_epi16(arr[15], arr[14], arr[13], arr[12], arr[11], arr[10], arr[9], arr[8]),
+	       _mm_set_epi16(arr[7], arr[6], arr[5], arr[4], arr[3], arr[2], arr[1], arr[0])) ;
+  }
+
+  static inline Vec vec_set1(Word val) {
+    return Vec(_mm_set1_epi16(val), _mm_set1_epi16(val)) ;
+  }
+
+  static inline Vec vec_add(const Vec& v1, const Vec& v2) {
+    return Vec(_mm_add_epi16(v1.v[1], v2.v[1]), 
+	       _mm_add_epi16(v1.v[0], v2.v[0])) ;
+  }
+
+  static inline Vec vec_or(const Vec& v1, const Vec& v2) {
+    return Vec(_mm_or_si128(v1.v[1], v2.v[1]),
+	       _mm_or_si128(v1.v[0], v2.v[0])) ;
+  }
+
+  static inline Vec vec_max(const Vec& v1, const Vec& v2) {
+    return Vec(_mm_max_epi16(v1.v[1], v2.v[1]), 
+	       _mm_max_epi16(v1.v[0], v2.v[0])) ;
+  }
+
+  static inline Vec vec_compare_eq(const Vec& v1, const Vec& v2) {
+    return Vec(_mm_cmpeq_epi16(v1.v[1], v2.v[1]), 
+	       _mm_cmpeq_epi16(v1.v[0], v2.v[0])) ;
+  }
+
+  static inline Vec vec_compare_gt(const Vec& v1, const Vec& v2) {
+    return Vec(_mm_cmpgt_epi16(v1.v[1], v2.v[1]), 
+	       _mm_cmpgt_epi16(v1.v[0], v2.v[0])) ;
+  }
+  
+  static inline Vec vec_blend(const Vec& vFalse, const Vec& vTrue, const Vec& mask) {
+    return Vec(_mm_blendv_epi8(vFalse.v[1], vTrue.v[1], mask.v[1]), 
+	       _mm_blendv_epi8(vFalse.v[0], vTrue.v[0], mask.v[0])) ;
+  }
+
+  static inline bool vec_test_all_ones(const Vec& vec, const Vec& allOnesV) {
+    return _mm_test_all_ones(vec.v[1]) && _mm_test_all_ones(vec.v[0]) ;
+  }
+
+  // 0 is inserted to LSW
+  static inline Vec vec_shift_left (const Vec& vec) {
+    return Vec(_mm_alignr_epi8(vec.v[1], vec.v[0], 14),
+	       _mm_slli_si128(vec.v[0], 2)) ;
+  }
+
+  // The most significant word (MSW) in words is inserted to LSW of vec
+  static inline Vec vec_shift_left_and_insert (const Vec& vec, const Vec& words) {
+    return Vec(_mm_alignr_epi8(vec.v[1], vec.v[0], 14),
+	       _mm_alignr_epi8(vec.v[0], words.v[1], 14)) ;
+  }
+
+  // 0 is inserted to MSW
+  static inline Vec vec_shift_right (const Vec& vec) {
+    return Vec(_mm_srli_si128(vec.v[1], 2),
+	       _mm_alignr_epi8(vec.v[1], vec.v[0], 2)) ;
+  }
+  
+  // The LSW of words is inserted to the MSW of vec
+  static inline Vec vec_shift_right_and_insert (const Vec& vec, const Vec& words) {
+    return Vec(_mm_alignr_epi8(words.v[0], vec.v[1], 2),
+	       _mm_alignr_epi8(vec.v[1], vec.v[0], 2)) ;
+  }
+
+  static void vec_print(const Vec& vec) ;
+
+} ;
+
+void EC16BitSSE_16::vec_print(const Vec& vec) {
+  for(int i = 7; i >= 0; i--)
+    cout << std::setw(5) << ((const int16_t*) (&vec.v[1]))[i] << " " ;
+
+  for(int i = 7; i >= 0; i--)
+    cout << std::setw(5) << ((const int16_t*) (&vec.v[0]))[i] << " " ;
+
+  cout << endl ;
+}
+

--- a/intel_opt/extend_vec256.h
+++ b/intel_opt/extend_vec256.h
@@ -1,0 +1,103 @@
+/* 
+The MIT License (MIT)
+Copyright (c) 2014 Intel Corp.
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include <immintrin.h>
+
+#include <iostream>
+#include <iomanip>
+#include <stdint.h>
+#include <stdlib.h>
+#include <assert.h>
+
+using std::cout ;
+using std::endl ;
+
+class EC16BitAvx2 {
+
+public:
+  
+  typedef __m256i Vec ;
+  typedef int16_t Word ;
+
+  static const int MAX_VEC_LEN = 16 ;
+  static const int BAD_SCORE = -1000 ;
+
+  
+  static inline Vec vec_set(Word* arr) {
+    return _mm256_set_epi16(arr[15], arr[14], arr[13], arr[12], arr[11],
+			    arr[10], arr[9], arr[8], arr[7], arr[6], arr[5],
+			    arr[4], arr[3], arr[2], arr[1], arr[0]) ;
+  }
+
+  static inline Vec vec_set1(Word val) {
+    return _mm256_set1_epi16(val) ;
+  }
+
+  static inline Vec vec_set_last_word(Word val) {
+    return _mm256_set_epi16(val, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) ;
+  }
+
+  static inline Vec vec_add(const Vec& v1, const Vec& v2) {
+    return _mm256_add_epi16(v1, v2) ;
+  }
+
+  static inline Vec vec_or(const Vec& v1, const Vec& v2) {
+    return _mm256_or_si256(v1, v2) ;
+  }
+
+  static inline Vec vec_max(const Vec& v1, const Vec& v2) {
+    return _mm256_max_epi16(v1, v2) ;
+  }
+
+  static inline Vec vec_compare_eq(const Vec& v1, const Vec& v2) {
+    return _mm256_cmpeq_epi16(v1, v2) ;
+  }
+
+  static inline Vec vec_compare_gt(const Vec& v1, const Vec& v2) {
+    return _mm256_cmpgt_epi16(v1, v2) ;
+  }
+  
+  static inline Vec vec_blend(const Vec& vFalse, const Vec& vTrue, const Vec& mask) {
+    return _mm256_blendv_epi8(vFalse, vTrue, mask) ;
+  }
+
+  static inline bool vec_test_all_ones(const Vec& v, const Vec& allOnesV) {
+    return _mm256_testc_si256(v, allOnesV) ;
+  }
+
+  // 0 is inserted to LSW
+  static inline __m256i vec_shift_left (const __m256i& vec) {
+    return _mm256_alignr_epi8(vec, _mm256_permute2x128_si256(vec, vec, 0x04), 14) ;
+  }
+
+  // The most significant word (MSW) in words is inserted to LSW of vec
+  static inline __m256i vec_shift_left_and_insert (const __m256i& vec, const __m256i& words) {
+    return _mm256_alignr_epi8(vec, _mm256_permute2x128_si256(vec, words, 0x03), 14) ;
+  }
+
+  // 0 is inserted to LSW
+  static inline __m256i vec_shift_right (const __m256i& vec) {
+    return _mm256_alignr_epi8(_mm256_permute2x128_si256(vec, vec, 0x41), vec, 2) ;
+  }
+
+  // The LSW of words is inserted to the MSW of vec
+  static inline __m256i vec_shift_right_and_insert (const __m256i& vec, const __m256i& words) {
+  
+    return _mm256_alignr_epi8(_mm256_permute2x128_si256(vec, words, 0x21), vec, 2) ;
+  }
+
+  static void vec_print(const Vec& vec) ;
+
+} ;
+
+void EC16BitAvx2::vec_print(const Vec& vec) {
+  for(int i = 15; i >= 0; i--)
+    cout << std::setw(5) << ((int16_t *)&vec)[i] << " " ;
+  cout << endl ;
+}
+

--- a/intel_opt/extend_vec256x2.h
+++ b/intel_opt/extend_vec256x2.h
@@ -1,0 +1,121 @@
+/* 
+The MIT License (MIT)
+Copyright (c) 2014 Intel Corp.
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include <immintrin.h>
+
+#include <iostream>
+#include <iomanip>
+#include <stdint.h>
+#include <stdlib.h>
+#include <assert.h>
+
+using std::cout ;
+using std::endl ;
+
+class EC16BitAvx2_32 {
+
+public:
+  
+  typedef int16_t Word ;
+
+  struct Vec {
+    __m256i v[2]; 
+
+    Vec(){}
+    explicit Vec(__m256i v1, __m256i v0) {
+      v[1] = v1 ;
+      v[0] = v0 ;
+    }
+
+  } ;
+
+
+  static const int MAX_VEC_LEN = 32 ;
+  static const int BAD_SCORE = -1000 ;
+  
+  static inline Vec vec_set(Word* arr) {
+
+    return Vec(_mm256_set_epi16(arr[31], arr[30], arr[29], arr[28], arr[27],
+				arr[26], arr[25], arr[24], arr[23], arr[22], arr[21],
+				arr[20], arr[19], arr[18], arr[17], arr[16]),
+	       _mm256_set_epi16(arr[15], arr[14], arr[13], arr[12], arr[11],
+				arr[10], arr[9], arr[8], arr[7], arr[6], arr[5],
+				arr[4], arr[3], arr[2], arr[1], arr[0])) ;
+  }
+
+  static inline Vec vec_set1(Word val) {
+    return Vec(_mm256_set1_epi16(val), _mm256_set1_epi16(val)) ;
+  }
+
+  static inline Vec vec_add(const Vec& v1, const Vec& v2) {
+    return Vec(_mm256_add_epi16(v1.v[1], v2.v[1]), _mm256_add_epi16(v1.v[0], v2.v[0])) ;
+  }
+
+  static inline Vec vec_or(const Vec& v1, const Vec& v2) {
+    return Vec(_mm256_or_si256(v1.v[1], v2.v[1]), _mm256_or_si256(v1.v[0], v2.v[0])) ;
+  }
+
+  static inline Vec vec_max(const Vec& v1, const Vec& v2) {
+    return Vec(_mm256_max_epi16(v1.v[1], v2.v[1]), _mm256_max_epi16(v1.v[0], v2.v[0])) ;
+  }
+
+  static inline Vec vec_compare_eq(const Vec& v1, const Vec& v2) {
+    return Vec(_mm256_cmpeq_epi16(v1.v[1], v2.v[1]), _mm256_cmpeq_epi16(v1.v[0], v2.v[0])) ;
+  }
+
+  static inline Vec vec_compare_gt(const Vec& v1, const Vec& v2) {
+    return Vec(_mm256_cmpgt_epi16(v1.v[1], v2.v[1]), _mm256_cmpgt_epi16(v1.v[0], v2.v[0])) ;
+  }
+  
+  static inline Vec vec_blend(const Vec& vFalse, const Vec& vTrue, const Vec& mask) {
+    return Vec(_mm256_blendv_epi8(vFalse.v[1], vTrue.v[1], mask.v[1]), 
+	       _mm256_blendv_epi8(vFalse.v[0], vTrue.v[0], mask.v[0])) ;
+  }
+
+  static inline bool vec_test_all_ones(const Vec& vec, const Vec& allOnesV) {
+    return _mm256_testc_si256(vec.v[0], allOnesV.v[0]) && 
+      _mm256_testc_si256(vec.v[1], allOnesV.v[0]) ;
+  }
+
+
+  // 0 is inserted to LSW
+  static inline Vec vec_shift_left (const Vec& vec) {
+    return Vec(_mm256_alignr_epi8(vec.v[1], _mm256_permute2x128_si256(vec.v[1], vec.v[0], 0x03), 14),
+	       _mm256_alignr_epi8(vec.v[0], _mm256_permute2x128_si256(vec.v[0], vec.v[0], 0x04), 14)) ;
+  }
+
+  // The most significant word (MSW) in words is inserted to LSW of vec
+  static inline Vec vec_shift_left_and_insert (const Vec& vec, const Vec& words) {
+    return Vec(_mm256_alignr_epi8(vec.v[1], _mm256_permute2x128_si256(vec.v[1], vec.v[0], 0x03), 14),
+	       _mm256_alignr_epi8(vec.v[0], _mm256_permute2x128_si256(vec.v[0], words.v[1], 0x03), 14)) ;
+  }
+  
+  // 0 is inserted to LSW
+  static inline Vec vec_shift_right (const Vec& vec) {
+    return Vec(_mm256_alignr_epi8(_mm256_permute2x128_si256(vec.v[1], vec.v[1], 0x41), vec.v[1], 2),
+	       _mm256_alignr_epi8(_mm256_permute2x128_si256(vec.v[0], vec.v[1], 0x21), vec.v[0], 2)) ;
+  }
+
+  // The LSW of words is inserted to the MSW of vec
+  static inline Vec vec_shift_right_and_insert (const Vec& vec, const Vec& words) {
+    return Vec(_mm256_alignr_epi8(_mm256_permute2x128_si256(vec.v[1], words.v[0], 0x21), vec.v[1], 2),
+	       _mm256_alignr_epi8(_mm256_permute2x128_si256(vec.v[0], vec.v[1], 0x21), vec.v[0], 2));
+  }
+
+  static void vec_print(const Vec& vec) ;
+
+} ;
+
+void EC16BitAvx2_32::vec_print(const Vec& vec) {
+  for(int i = 15; i >= 0; i--)
+    cout << std::setw(5) << ((int16_t *)&vec.v[1])[i] << " " ;
+  for(int i = 15; i >= 0; i--)
+    cout << std::setw(5) << ((int16_t *)&vec.v[0])[i] << " " ;
+  cout << endl ;
+}
+

--- a/intel_opt/fast_extend.h
+++ b/intel_opt/fast_extend.h
@@ -1,0 +1,79 @@
+/* 
+The MIT License (MIT)
+Copyright (c) 2014 Intel Corp.
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+extern const int defaultCostMatrixRowCnt ;
+
+extern const int8_t defaultCostMatrix[] ;
+
+bool useavx2;
+// Needs to be called only once per program to set up static arrays
+void init_fast_extend(bool avx2present) ;
+
+
+// The filtering function:
+// Inputs: Reference and query sequences,	
+//         Initial score (i.e. h0),
+//         endBonus (i.e. the extra score if the whole query is aligned)
+//         Scoring parameters: mismatchWt, gapWt, gapOpenWt, ambigWt
+// Outputs:
+//         Alignment length in query
+//         Alignment length in reference
+//         Alignment score
+//         Confidence: For now, it's either 0.0 or 1.0, corresponding to no/full confidence in outputs
+// Usage:
+//         If confidence == 0.0: Partial alignment - need to rerun ksw_extend(...)
+//         If confidence == 1.0
+//               if alignedQLen == queryLen: Full alignment
+//               if alignedQLen == 0: No alignment
+//
+void fast_filter(const uint8_t* refSeq, int refLen, const uint8_t* querySeq, int queryLen,
+		 int initScore, int endBonus, 
+		 int& alignedQLen, int& alignedRLen, int& score, float& confidence,
+		 int mismatchWt=4, int gapWt=1, int gapOpenWt=6, int ambigWt=1) ;
+
+// Filter-and-extend function:
+// Inputs: Reference and query sequences,	
+//         Initial score (i.e. h0),
+//         endBonus (i.e. the extra score if the whole query is aligned)
+//         zdrop value passed to ksw_extend
+//         Cost matrix and gap open and gap extend weights
+// Outputs:
+//         Alignment length in query
+//         Alignment length in reference
+//         Alignment score
+// Behavior:
+//         The filtering function will be called internally first.
+//         If there is an obvious result, it will be returned.
+//         If not, ksw_extend() will be called with feedback from filtering function,
+//         and its result will be returned.
+// Notes: 
+//        It is assumed that ksw_extend(...) function is in a linked file.
+//
+void fast_filter_and_extend(const uint8_t* refSeq, int refLen, const uint8_t* querySeq, int queryLen,
+			    int initScore, int endBonus, int zdrop,
+			    int& alignedQLen, int& alignedRLen, int& score,
+			    int costMatrixRowCnt=defaultCostMatrixRowCnt, 
+			    const int8_t* costMatrix=defaultCostMatrix,
+			    int gapWt=1, int gapOpenWt=6) ;
+
+int (*ksw_extend_16)(int qlen, const uint8_t *query, int tlen, const uint8_t *target, int m, const int8_t *mat, int gapo, int gape, int w, int end_bonus, int zdrop, int h0, int *qle, int *tle, int *gtle, int *gscore, int *max_off) ;
+int (*ksw_extend_32)(int qlen, const uint8_t *query, int tlen, const uint8_t *target, int m, const int8_t *mat, int gapo, int gape, int w, int end_bonus, int zdrop, int h0, int *qle, int *tle, int *gtle, int *gscore, int *max_off) ;
+
+
+// Vectorized implementations of ksw_extend for small bands:
+int ksw_extend_sse_8(int qlen, const uint8_t *query, int tlen, const uint8_t *target, int m, const int8_t *mat, int gapo, int gape, int w, int end_bonus, int zdrop, int h0, int *qle, int *tle, int *gtle, int *gscore, int *max_off) ;
+
+int ksw_extend_sse_16(int qlen, const uint8_t *query, int tlen, const uint8_t *target, int m, const int8_t *mat, int gapo, int gape, int w, int end_bonus, int zdrop, int h0, int *qle, int *tle, int *gtle, int *gscore, int *max_off) ;
+
+
+
+int ksw_extend_avx2_16(int qlen, const uint8_t *query, int tlen, const uint8_t *target, int m, const int8_t *mat, int gapo, int gape, int w, int end_bonus, int zdrop, int h0, int *qle, int *tle, int *gtle, int *gscore, int *max_off) ;
+
+int ksw_extend_avx2_32(int qlen, const uint8_t *query, int tlen, const uint8_t *target, int m, const int8_t *mat, int gapo, int gape, int w, int end_bonus, int zdrop, int h0, int *qle, int *tle, int *gtle, int *gscore, int *max_off) ;
+
+

--- a/intel_opt/fast_extend_bitv128.h
+++ b/intel_opt/fast_extend_bitv128.h
@@ -1,0 +1,163 @@
+/* 
+The MIT License (MIT)
+Copyright (c) 2014 Intel Corp.
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef _FAST_EXTEND_BITV128_H
+#define _FAST_EXTEND_BITV128_H
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <iostream>
+
+using namespace std ;
+
+class BitVec128 {
+
+  __m128i bitV ;
+
+public:
+  
+  BitVec128():  bitV(_mm_setzero_si128()) {}
+
+  explicit BitVec128(const __m128i& v): bitV(v) {}
+
+  inline uint16_t getLow16Bits() const {
+    return (uint16_t) _mm_extract_epi16(bitV, 0) ;
+  }
+
+  inline void setAll64BitWords(uint64_t val) {
+    bitV = _mm_set1_epi64x(val) ;
+  }
+
+  inline void setAllOnes () {
+    bitV = _mm_set1_epi8(0xFF) ;
+  }
+
+  inline void setAllZeroes () {
+    bitV = _mm_setzero_si128() ;
+  }
+
+  inline void setAllBits (bool bit) {
+    if (bit) setAllOnes() ;
+    else setAllZeroes() ;
+  }
+
+  inline void setLSBClearRest (bool bit) {
+    bitV = _mm_set_epi64x(0x0, bit) ;
+  }
+
+  inline void shiftLeftAndInsert (bool newBit) {
+
+    static const __m128i lsbSetVec = _mm_set_epi64x(0x0, 0x1) ; // only the 0th bit is 1, rest are 0
+    
+    bitV = _mm_or_si128(_mm_slli_epi64(bitV, 1),
+			_mm_srli_epi64(_mm_slli_si128(bitV, 8), 63)) ;
+    if (newBit)
+      bitV = _mm_or_si128(bitV, lsbSetVec) ;
+
+  }
+
+  inline void shiftLeft () {
+    bitV = _mm_or_si128(_mm_slli_epi64(bitV, 1),
+			_mm_srli_epi64(_mm_slli_si128(bitV, 8), 63)) ;
+
+  }
+
+ 
+  inline BitVec128 shiftProbesRight(int probeOffset, const BitVec128& shiftCnt) const {
+    
+    BitVec128 r ;
+    if (probeOffset == 15)
+      r.bitV = _mm_srli_si128(bitV, 2) ; // shift right by 16 bits (across 64-bit boundary)
+    else
+      r.bitV = _mm_srl_epi64(bitV, shiftCnt.bitV) ;
+
+    return r ;
+  }
+
+  void setWord (int index, uint64_t w) {
+    if (index == 0)
+      bitV = _mm_insert_epi64(bitV, w, 0) ;
+    else
+      bitV = _mm_insert_epi64(bitV, w, 1) ;
+  }
+
+  inline BitVec128 operator~ () const {
+    static const __m128i onesVec = _mm_set1_epi8(0xFF) ;
+
+    return BitVec128(_mm_andnot_si128(bitV, onesVec)) ;
+  }
+
+  inline BitVec128 operator& (const BitVec128& other) const {
+
+    return BitVec128(_mm_and_si128(bitV, other.bitV)) ;
+  }
+
+  inline BitVec128 andnot (const BitVec128& other) const {
+
+    return BitVec128(_mm_andnot_si128(other.bitV, bitV)) ;
+  }
+
+  inline BitVec128 operator| (const BitVec128& other) const {
+
+    return BitVec128(_mm_or_si128(bitV, other.bitV)) ;
+  }
+
+  inline BitVec128 operator^ (const BitVec128& other) const {
+
+    return BitVec128(_mm_xor_si128(bitV, other.bitV)) ;
+  }
+
+  inline BitVec128 operator+ (const BitVec128& other) const {
+
+
+    BitVec128 sum ;
+    sum.bitV = _mm_add_epi64(this->bitV, other.bitV) ;
+    
+    // We should add the carryout from the lower word (if any) to upper word
+
+    /*
+    static __m128i lsbSetVec = _mm_set1_epi64x(0x1) ;
+    static __m128i msbSetVec = _mm_set1_epi64x(0x8000000000000000) ;
+
+    // set pred to all 1s (0xFFFFFF...) in case of overflow
+    __m128i pred = _mm_cmpgt_epi64(_mm_xor_si128(this->bitV, msbSetVec),
+				   _mm_xor_si128(sum.bitV, msbSetVec)) ;
+    // Note: Since SSE does not have unsigned comparison opn, we first xor the MSBs,
+    // and then do the signed comparison
+
+    // If lower 64-bit of pred is set, add 0x1 to the upper word
+    sum.bitV = _mm_add_epi64(sum.bitV, _mm_and_si128(lsbSetVec, _mm_slli_si128(pred, 8))) ;
+    */
+    /* Alternative implementation: */
+    
+    uint64_t sumLower = _mm_extract_epi64(sum.bitV, 0) ;
+    uint64_t thisLower = _mm_extract_epi64(this->bitV, 0) ;
+    if (sumLower < thisLower) {
+      static __m128i carryVec = _mm_set_epi64x(0x1, 0x0) ;
+      sum.bitV = _mm_add_epi64(sum.bitV, carryVec) ;
+    }
+    
+
+    return sum ;
+  }
+
+  static bool isQueryLengthOk(int qlen) {
+    return qlen <= 127 ;
+  }
+
+  friend std::ostream& operator<< (std::ostream& os, const BitVec128& b) {
+    os << "{" << _mm_extract_epi64(b.bitV, 0) << " " << _mm_extract_epi64(b.bitV, 1) << "}" ;
+    return os ;
+  }
+
+  friend class EDVec128Every16 ;
+
+} ;
+
+
+#endif // #ifndef _FAST_EXTEND_BITV128_H

--- a/intel_opt/fast_extend_bitv128x2.h
+++ b/intel_opt/fast_extend_bitv128x2.h
@@ -1,0 +1,210 @@
+/* 
+The MIT License (MIT)
+Copyright (c) 2014 Intel Corp.
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef _FAST_EXTEND_BITV128x2_H
+#define _FAST_EXTEND_BITV128x2_H
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <iostream>
+
+using namespace std ;
+
+class BitVec128x2 {
+
+  __m128i bitV[2] ;
+
+public:
+  
+  BitVec128x2() {
+    bitV[0] = _mm_setzero_si128() ;
+    bitV[1] = _mm_setzero_si128() ;
+  }
+
+  explicit BitVec128x2(const __m128i& v0, const __m128i& v1) {
+    bitV[0] = v0 ;
+    bitV[1] = v1 ;
+  }
+
+  inline uint16_t getLow16Bits() const {
+    return (uint16_t) _mm_extract_epi16(bitV[0], 0) ;
+  }
+
+  inline void setAll64BitWords(uint64_t val) {
+    bitV[0] = _mm_set1_epi64x(val) ;
+    bitV[1] = _mm_set1_epi64x(val) ;
+  }
+
+  inline void setAllOnes () {
+    bitV[0] = _mm_set1_epi8(0xFF) ;
+    bitV[1] = _mm_set1_epi8(0xFF) ;
+  }
+
+  inline void setAllZeroes () {
+    bitV[0] = _mm_setzero_si128() ;
+    bitV[1] = _mm_setzero_si128() ;
+  }
+
+  inline void setAllBits (bool bit) {
+    if (bit) setAllOnes() ;
+    else setAllZeroes() ;
+  }
+
+  inline void setLSBClearRest (bool bit) {
+    bitV[0] = _mm_set_epi64x(0x0, bit) ;
+    bitV[1] = _mm_set_epi64x(0x0, 0x0) ;
+  }
+
+  inline void shiftLeftAndInsert (bool newBit) {
+
+    static const __m128i lsbSetVec = _mm_set_epi64x(0x0, 0x1) ; // only the 0th bit is 1, rest are 0
+    
+    // Shift the MSBs to LSB positions
+    __m128i msb2lsb0 = _mm_srli_epi64(bitV[0], 63) ;
+    __m128i msb2lsb1 = _mm_srli_epi64(bitV[1], 63) ;
+    
+    bitV[0] = _mm_or_si128(_mm_slli_epi64(bitV[0], 1),
+			   _mm_slli_si128(msb2lsb0, 8)) ;
+    
+    bitV[1] = _mm_or_si128(_mm_slli_epi64(bitV[1], 1),
+			   _mm_alignr_epi8(msb2lsb1, msb2lsb0, 8)) ;
+
+    if (newBit)
+      bitV[0] = _mm_or_si128(bitV[0], lsbSetVec) ;
+  }
+
+  inline void shiftLeft () {
+    // Shift the MSBs to LSB positions
+    __m128i msb2lsb0 = _mm_srli_epi64(bitV[0], 63) ;
+    __m128i msb2lsb1 = _mm_srli_epi64(bitV[1], 63) ;
+    
+    bitV[0] = _mm_or_si128(_mm_slli_epi64(bitV[0], 1),
+			   _mm_slli_si128(msb2lsb0, 8)) ;
+    
+    bitV[1] = _mm_or_si128(_mm_slli_epi64(bitV[1], 1),
+			   _mm_alignr_epi8(msb2lsb1, msb2lsb0, 8)) ;
+  }
+
+  inline BitVec128x2 shiftProbesRight(int probeOffset, const BitVec128x2& shiftCnt) const {
+    
+    BitVec128x2 r ;
+    if (probeOffset == 15) {
+      // shift right by 16 bits (across 128-bit boundary)
+      r.bitV[0] = _mm_or_si128(_mm_srli_si128(bitV[0], 2),
+			       _mm_slli_si128(bitV[1], 14)) ;
+      r.bitV[1] = _mm_srli_si128(bitV[1], 2) ;
+    }
+    else {
+      // shift right by shiftCnt within each 16-bit word
+      r.bitV[0] = _mm_srl_epi64(bitV[0], shiftCnt.bitV[0]) ;
+      r.bitV[1] = _mm_srl_epi64(bitV[1], shiftCnt.bitV[1]) ;
+    }
+
+    return r ;
+  }
+
+  void setWord (int index, uint64_t w) {
+    switch(index) {
+    case 0: bitV[0] = _mm_insert_epi64(bitV[0], w, 0) ; break ;
+    case 1: bitV[0] = _mm_insert_epi64(bitV[0], w, 1) ; break ;
+    case 2: bitV[1] = _mm_insert_epi64(bitV[1], w, 0) ; break ;
+    case 3: bitV[1] = _mm_insert_epi64(bitV[1], w, 1) ; break ;
+    default: assert(false) ;
+    }
+  }
+
+  inline BitVec128x2 operator~ () const {
+    static const __m128i onesVec = _mm_set1_epi8(0xFF) ;
+
+    return BitVec128x2(_mm_andnot_si128(bitV[0], onesVec),
+		       _mm_andnot_si128(bitV[1], onesVec)) ;
+  }
+
+  inline BitVec128x2 operator& (const BitVec128x2& other) const {
+
+    return BitVec128x2(_mm_and_si128(bitV[0], other.bitV[0]),
+		       _mm_and_si128(bitV[1], other.bitV[1])) ;
+  }
+
+  inline BitVec128x2 andnot (const BitVec128x2& other) const {
+
+    return BitVec128x2(_mm_andnot_si128(other.bitV[0], bitV[0]),
+		       _mm_andnot_si128(other.bitV[1], bitV[1])) ;
+  }
+
+  inline BitVec128x2 operator| (const BitVec128x2& other) const {
+
+    return BitVec128x2(_mm_or_si128(bitV[0], other.bitV[0]),
+		       _mm_or_si128(bitV[1], other.bitV[1])) ;
+  }
+
+  inline BitVec128x2 operator^ (const BitVec128x2& other) const {
+
+    return BitVec128x2(_mm_xor_si128(bitV[0], other.bitV[0]),
+		       _mm_xor_si128(bitV[1], other.bitV[1])) ;
+  }
+
+  inline BitVec128x2 operator+ (const BitVec128x2& other) const {
+
+    BitVec128x2 sum ;
+    sum.bitV[0] = _mm_add_epi64(this->bitV[0], other.bitV[0]) ;
+    sum.bitV[1] = _mm_add_epi64(this->bitV[1], other.bitV[1]) ;
+    
+    // We should add the carryout from the lower word (if any) to upper word
+
+    uint64_t sum0 = _mm_extract_epi64(sum.bitV[0], 0) ;
+    uint64_t this0 = _mm_extract_epi64(this->bitV[0], 0) ;
+    uint carry0 = (sum0 < this0) ? 1 : 0 ;
+
+    uint64_t sum1 = _mm_extract_epi64(sum.bitV[0], 1) ;
+    uint64_t this1 = _mm_extract_epi64(this->bitV[0], 1) ;
+    uint carry1 = (sum1 < this1) ? 1 : 0 ;
+
+    uint64_t sum2 = _mm_extract_epi64(sum.bitV[1], 0) ;
+    uint64_t this2 = _mm_extract_epi64(this->bitV[1], 0) ;
+    uint carry2 = (sum2 < this2) ? 1 : 0 ;
+
+    uint64_t sum3 = _mm_extract_epi64(sum.bitV[1], 1) ;
+
+    sum1 += carry0 ;
+    sum2 += carry1 ;
+    sum3 += carry2 ;
+
+    carry2 = carry1 && (sum2 == 0) ;
+    carry1 = carry0 && (sum1 == 0) ;
+
+    sum2 += carry1 ;
+    sum3 += carry2 ;
+    
+    carry2 = carry1 && (sum2 == 0) ;
+    sum3 += carry2 ;
+
+    sum.bitV[0] = _mm_set_epi64x(sum1, sum0) ;
+    sum.bitV[1] = _mm_set_epi64x(sum3, sum2) ;
+
+    return sum ;
+  }
+
+  static bool isQueryLengthOk(int qlen) {
+    return qlen <= 255 ;
+  }
+
+  friend std::ostream& operator<< (std::ostream& os, const BitVec128x2& b) {
+    os << "{" << _mm_extract_epi64(b.bitV[0], 0) << " " << _mm_extract_epi64(b.bitV[0], 1) << " "
+       << _mm_extract_epi64(b.bitV[1], 0) << " " << _mm_extract_epi64(b.bitV[1], 1) << "}" ;
+    return os ;
+  }
+
+  friend class EDVec128x2Every16 ;
+  friend class EDVec256Every16 ;
+  
+} ;
+
+
+
+#endif // #ifndef _FAST_EXTEND_BITV128_H

--- a/intel_opt/fast_extend_bitv256.h
+++ b/intel_opt/fast_extend_bitv256.h
@@ -1,0 +1,257 @@
+/* 
+The MIT License (MIT)
+Copyright (c) 2014 Intel Corp.
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef _FAST_EXTEND_BITV256_H
+#define _FAST_EXTEND_BITV256_H
+
+#include <immintrin.h>
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <iostream>
+
+using namespace std ;
+
+class BitVec256 {
+
+  __m256i bitV ;
+
+public:
+  
+  BitVec256() {
+    bitV = _mm256_setzero_si256() ;
+  }
+
+  explicit BitVec256(const __m256i& v) {
+    bitV = v ;
+  }
+
+  inline uint16_t getLow16Bits() const {
+    return (uint16_t) _mm_extract_epi16(_mm256_castsi256_si128(bitV), 0) ;
+  }
+
+  inline void setAll64BitWords(uint64_t val) {
+    bitV = _mm256_set1_epi64x(val) ;
+  }
+
+  inline void setAllOnes () {
+    bitV = _mm256_set1_epi8(0xFF) ;
+  }
+
+  inline void setAllZeroes () {
+    bitV = _mm256_setzero_si256() ;
+  }
+
+  inline void setAllBits (bool bit) {
+    if (bit) setAllOnes() ;
+    else setAllZeroes() ;
+  }
+
+  inline void setLSBClearRest (bool bit) {
+    bitV = _mm256_set_epi64x(0x0, 0x0, 0x0, bit) ;
+  }
+
+  inline void shiftLeftAndInsert (bool newBit) {
+
+    static const __m256i lsbSetVec = _mm256_set_epi64x(0x0, 0x0, 0x0, 0x1) ; // only the 0th bit is 1, rest are 0
+    static const __m256i lsbClearVec = _mm256_set_epi64x(0xFFFFFFFFFFFFFFFF, 
+							 0xFFFFFFFFFFFFFFFF, 
+							 0xFFFFFFFFFFFFFFFF, 
+							 0xFFFFFFFFFFFFFFFE) ; // only the 0th bit is 0, rest are 1
+    
+    // Shift the MSBs to LSB positions
+    __m256i msb2lsb = _mm256_srli_epi64(bitV, 63) ;
+
+    // Permute 64-bit words as follows to shift words left
+    // v[0] = v[0] ;
+    // v[1] = v[0] ;
+    // v[2] = v[1] ;
+    // v[3] = v[2] ;
+    // Selector bits: 10 01 00 00 = 0x90
+    bitV = _mm256_or_si256(_mm256_slli_epi64(bitV, 1),
+			   _mm256_permute4x64_epi64(msb2lsb, 0x90)) ;
+
+    // The LSB needs to be set or cleared based on input
+    if (newBit)
+      bitV = _mm256_or_si256(bitV, lsbSetVec) ;
+    else
+      bitV = _mm256_and_si256(bitV, lsbClearVec) ;
+  }
+
+  inline void shiftLeft () {
+
+    static const __m256i lsbClearVec = _mm256_set_epi64x(0xFFFFFFFFFFFFFFFF, 
+							 0xFFFFFFFFFFFFFFFF, 
+							 0xFFFFFFFFFFFFFFFF, 
+							 0xFFFFFFFFFFFFFFFE) ; // only the 0th bit is 0, rest are 1
+    
+    // Shift the MSBs to LSB positions
+    __m256i msb2lsb = _mm256_srli_epi64(bitV, 63) ;
+
+    // Permute 64-bit words as follows to shift words left
+    // v[0] = v[0] ;
+    // v[1] = v[0] ;
+    // v[2] = v[1] ;
+    // v[3] = v[2] ;
+    // Selector bits: 10 01 00 00 = 0x90
+    bitV = _mm256_or_si256(_mm256_slli_epi64(bitV, 1),
+			   _mm256_permute4x64_epi64(msb2lsb, 0x90)) ;
+
+    // The LSB needs to be cleared
+    bitV = _mm256_and_si256(bitV, lsbClearVec) ;
+  }
+  
+  inline BitVec256 shiftProbesRight(int probeOffset, const BitVec256& shiftCnt) const {
+    
+    BitVec256 r ;
+    if (probeOffset == 15) {
+      // shift right by 16 bits (across 128-bit boundary)
+      r.bitV = _mm256_or_si256(_mm256_srli_si256(bitV, 2),
+			       _mm256_permute4x64_epi64(_mm256_slli_si256(bitV,14), 0x0C)) ;
+    }
+    else {
+      // shift right by shiftCnt within each 16-bit word
+      r.bitV = _mm256_srl_epi64(bitV, _mm256_castsi256_si128(shiftCnt.bitV)) ;
+    }
+
+    return r ;
+  }
+
+  void setWord (int index, uint64_t w) {
+    switch(index) {
+    case 0: bitV = _mm256_insertf128_si256(bitV, 
+					   _mm_insert_epi64(_mm256_castsi256_si128(bitV), w, 0),
+					   0) ; 
+      break ;
+
+    case 1: bitV = _mm256_insertf128_si256(bitV, 
+					   _mm_insert_epi64(_mm256_castsi256_si128(bitV), w, 1),
+					   0) ; 
+      break ;
+      
+    case 2: bitV = _mm256_insertf128_si256(bitV, 
+					   _mm_insert_epi64(_mm256_extractf128_si256(bitV, 1), 
+							    w, 0),
+					   1) ; 
+      break ;
+
+    case 3: bitV = _mm256_insertf128_si256(bitV, 
+					   _mm_insert_epi64(_mm256_extractf128_si256(bitV, 1), 
+							    w, 1),
+					   1) ; 
+      break ;
+
+    default: assert(false) ;
+    }
+  }
+
+  uint64_t getWord (int index) const {
+
+    switch(index) {
+    case 0: 
+      return _mm_extract_epi64(_mm256_castsi256_si128(bitV), 0) ;
+    case 1:
+      return _mm_extract_epi64(_mm256_castsi256_si128(bitV), 1) ;
+    case 2:
+      return _mm_extract_epi64(_mm256_extractf128_si256(bitV,1), 0) ;
+    case 3:
+      return _mm_extract_epi64(_mm256_extractf128_si256(bitV,1), 1) ;
+    default:
+      assert(false) ;
+    }
+
+    return 0 ;
+  }
+
+
+  
+  inline BitVec256 operator~ () const {
+    static const __m256i onesVec = _mm256_set1_epi8(0xFF) ;
+
+    return BitVec256(_mm256_andnot_si256(bitV, onesVec)) ;
+  }
+
+  inline BitVec256 operator& (const BitVec256& other) const {
+
+    return BitVec256(_mm256_and_si256(bitV, other.bitV)) ;
+  }
+
+  inline BitVec256 andnot (const BitVec256& other) const {
+
+    return BitVec256(_mm256_andnot_si256(other.bitV, bitV)) ;
+  }
+
+  inline BitVec256 operator| (const BitVec256& other) const {
+
+    return BitVec256(_mm256_or_si256(bitV, other.bitV)) ;
+  }
+
+  inline BitVec256 operator^ (const BitVec256& other) const {
+
+    return BitVec256(_mm256_xor_si256(bitV, other.bitV)) ;
+  }
+
+  inline BitVec256 operator+ (const BitVec256& other) const {
+
+    BitVec256 sum ;
+    sum.bitV = _mm256_add_epi64(this->bitV, other.bitV) ;
+    
+    // We should add the carryout from the lower word (if any) to upper word
+    static __m256i zeroVec = _mm256_set1_epi64x(0x0) ;
+    static __m256i lsbSetVec1 = _mm256_set_epi64x(0x1, 0x1, 0x1, 0x0) ;
+    static __m256i lsbSetVec2 = _mm256_set_epi64x(0x1, 0x1, 0x0, 0x0) ;
+    static __m256i lsbSetVec3 = _mm256_set_epi64x(0x1, 0x0, 0x0, 0x0) ;
+    static __m256i msbSetVec = _mm256_set1_epi64x(0x8000000000000000) ;
+
+    // set pred to all 1s (0xFFFFFF...) in case of overflow
+    __m256i pred = _mm256_cmpgt_epi64(_mm256_xor_si256(this->bitV, msbSetVec),
+				      _mm256_xor_si256(sum.bitV, msbSetVec)) ;
+    // Note: Since SSE/avx do not have unsigned comparison opn, we first xor the MSBs,
+    // and then do the signed comparison
+
+    __m256i carry1 = _mm256_permute4x64_epi64(pred, 0x90) ;
+
+    // If lower 64-bit of pred is set, add 0x1 to the upper word
+    sum.bitV = _mm256_add_epi64(sum.bitV, _mm256_and_si256(lsbSetVec1, carry1)) ;
+
+    // It seems rare that the second and third round carries are needed.
+    // We disable the code below for better performance.
+    return sum ; 
+
+    pred = _mm256_cmpeq_epi64(sum.bitV, zeroVec) ;
+    __m256i carry2 = _mm256_permute4x64_epi64(_mm256_and_si256(pred, carry1), 0x90) ;
+    sum.bitV = _mm256_add_epi64(sum.bitV, _mm256_and_si256(lsbSetVec2, carry2)) ;
+
+    pred = _mm256_cmpeq_epi64(sum.bitV, zeroVec) ;
+    __m256i carry3 = _mm256_permute4x64_epi64(_mm256_and_si256(pred, carry2), 0x90) ;
+    sum.bitV = _mm256_add_epi64(sum.bitV, _mm256_and_si256(lsbSetVec3, carry3)) ;
+					 
+    
+    return sum ; // zzz
+    
+  }
+
+  static bool isQueryLengthOk(int qlen) {
+    return qlen <= 255 ;
+  }
+
+  friend std::ostream& operator<< (std::ostream& os, const BitVec256& b) {
+    os << "{" <<  b.getWord(0) << " " << b.getWord(1) << " " << b.getWord(2) << " "
+       << b.getWord(3) << "}" ;
+
+    return os ;
+  }
+
+  friend class EDVec128x2Every16 ;
+  friend class EDVec256Every16 ;
+  
+} ;
+
+
+
+#endif // #ifndef _FAST_EXTEND_BITV128_H

--- a/intel_opt/fast_extend_bitv64.h
+++ b/intel_opt/fast_extend_bitv64.h
@@ -1,0 +1,130 @@
+/* 
+The MIT License (MIT)
+Copyright (c) 2014 Intel Corp.
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef _FAST_EXTEND_BITV64_H
+#define _FAST_EXTEND_BITV64_H
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <limits>
+
+class BitVec64 {
+
+  uint64_t bitV ;
+
+  explicit BitVec64(uint64_t val): bitV(val) {}
+
+public:
+  
+  BitVec64(): bitV(0x0) {}
+
+  inline bool getLSB() const {
+    return bitV & 0x1 ;
+  }
+  
+  inline uint16_t getLow16Bits() const {
+    return (uint16_t) bitV ;
+  }
+
+  inline void setAll64BitWords(uint64_t val) {
+    bitV = val ;
+  }
+
+  inline void setAllOnes () {
+    bitV = 0xFFFFFFFFFFFFFFFF ;
+  }
+
+  inline void setAllZeroes () {
+    bitV = 0x0000000000000000 ;
+  }
+
+  inline void setAllBits (bool bit) {
+    bitV = bit ? 0xFFFFFFFFFFFFFFFF : 0x0 ;
+  }
+
+  inline void setLSBClearRest (bool bit) {
+    bitV = bit ;
+  }
+
+  inline void setBit(int bitIndex, bool bit) {
+    uint64_t mask = ((uint64_t)0x1) << bitIndex ;
+    bitV = bit ? (bitV | mask) : (bitV & ~mask) ;
+  }
+
+  inline void shiftLeftAndInsert (bool newBit) {
+    bitV = (bitV << 1) | ((uint8_t) newBit) ;
+  }
+
+  inline void shiftLeft () {
+    bitV <<= 1 ;
+  }
+
+  inline BitVec64 shiftProbesRight(int probeOffset, const BitVec64& shiftCnt) const {
+    // The carryout bit is at location probeOffset+1
+    return BitVec64(bitV >> (probeOffset+1)) ;
+  }
+
+  void setWord (int index, uint64_t w) {
+    bitV = w ;
+  }
+
+  inline void orBitAtPosition (bool newBit, int index) {
+    bitV |= (((uint64_t)newBit) << index) ;
+  }
+  
+  inline bool getMSB() const {
+    return bitV & 0x8000000000000000 ;
+  }
+
+  inline BitVec64 operator~ () const {
+    return BitVec64(~this->bitV) ;
+  }
+
+  inline BitVec64 operator& (const BitVec64& other) const {
+    return BitVec64(this->bitV & other.bitV) ;
+  }
+
+  inline BitVec64 andnot (const BitVec64& other) const {
+    return *this & (~other) ;
+  }
+
+  inline BitVec64 operator| (const BitVec64& other) const {
+    return BitVec64(this->bitV | other.bitV) ;
+  }
+
+  inline BitVec64 operator^ (const BitVec64& other) const {
+    return BitVec64(this->bitV ^ other.bitV) ;
+  }
+
+  inline BitVec64 operator+ (const BitVec64& other) const {
+    return BitVec64(this->bitV + other.bitV) ;
+  }
+
+  static bool isQueryLengthOk(int qlen) {
+    return qlen < 64 ;
+  }
+
+  bool getBit (int index) const {
+    return (bitV >> index) & 0x1 ;
+  }
+
+  friend std::ostream& operator<< (std::ostream& os, const BitVec64& b) {
+    os << b.bitV ;
+    return os ;
+  }
+
+  friend class EDVec64 ;
+  friend class EDVec128Every16 ;
+  friend class EDVec64Every8 ;
+  friend class EDVec32Every4 ;
+  friend class EDVec16Every1 ;
+} ;
+
+
+
+#endif // #ifndef _FAST_EXTEND_BITV64_H

--- a/intel_opt/fast_extend_bitv64x2.h
+++ b/intel_opt/fast_extend_bitv64x2.h
@@ -1,0 +1,149 @@
+/* 
+The MIT License (MIT)
+Copyright (c) 2014 Intel Corp.
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef _FAST_EXTEND_BITV64x2_H
+#define _FAST_EXTEND_BITV64x2_H
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <iostream>
+#include <iomanip>
+
+using namespace std ;
+
+class BitVec64x2 {
+
+  uint64_t bitV[2] ;
+
+public:
+  
+  BitVec64x2() {
+    bitV[0] = 0x0 ;
+    bitV[1] = 0x0 ;
+  }
+
+  inline bool getLSB() const {
+    return bitV[0] & 0x1 ;
+  }
+
+  inline uint16_t getLow16Bits() const {
+    return (uint16_t) bitV[0] ;
+  }
+
+  inline void setAll64BitWords(uint64_t val) {
+    bitV[0] = bitV[1] = val ;
+  }
+
+  inline void setAllOnes () {
+    bitV[0] = 0xFFFFFFFFFFFFFFFF ;
+    bitV[1] = 0xFFFFFFFFFFFFFFFF ;
+  }
+
+  inline void setAllZeroes () {
+    bitV[0] = 0x0000000000000000 ;
+    bitV[1] = 0x0000000000000000 ;
+  }
+
+  inline void setAllBits (bool bit) {
+    if (bit) setAllOnes() ;
+    else setAllZeroes() ;
+  }
+
+  inline void setLSBClearRest (bool bit) {
+    bitV[0] = bit ;
+    bitV[1] = 0x0 ;
+  }
+
+  inline void shiftLeftAndInsert (bool newBit) {
+    bitV[1] <<= 1 ;
+    bitV[1] |= (bitV[0] >> 63) ;
+    bitV[0] <<= 1 ;
+    bitV[0] |= ((uint8_t) newBit) ;
+  }
+
+  inline void shiftLeft () {
+    bitV[1] <<= 1 ;
+    bitV[1] |= (bitV[0] >> 63) ;
+    bitV[0] <<= 1 ;
+  }
+
+  
+  inline BitVec64x2 shiftProbesRight(int probeOffset, const BitVec64x2& shiftCnt) const {
+    BitVec64x2 r ;
+
+    r.bitV[0] = bitV[0] >> (probeOffset + 1) ;
+
+    if (probeOffset == 15) 
+      r.bitV[0] |= ((bitV[1] & 0x1) << 48) ; 
+
+    r.bitV[1] = bitV[1] >> (probeOffset + 1) ;
+    return r ;
+  }
+  
+
+  void setWord (int index, uint64_t w) {
+    bitV[index] = w ;
+  }
+
+  inline BitVec64x2 operator~ () const {
+    BitVec64x2 r ;
+    r.bitV[0] = ~this->bitV[0] ;
+    r.bitV[1] = ~this->bitV[1] ;
+    return r ;
+  }
+
+  inline BitVec64x2 operator& (const BitVec64x2& other) const {
+    BitVec64x2 r ;
+    r.bitV[0] = this->bitV[0] & other.bitV[0] ;
+    r.bitV[1] = this->bitV[1] & other.bitV[1] ;
+    return r ;
+  }
+
+  inline BitVec64x2 andnot (const BitVec64x2& other) const {
+    return *this & (~other) ;
+  }
+
+  inline BitVec64x2 operator| (const BitVec64x2& other) const {
+    BitVec64x2 r ;
+    r.bitV[0] = this->bitV[0] | other.bitV[0] ;
+    r.bitV[1] = this->bitV[1] | other.bitV[1] ;
+    return r ;
+  }
+
+  inline BitVec64x2 operator^ (const BitVec64x2& other) const {
+    BitVec64x2 r ;
+    r.bitV[0] = this->bitV[0] ^ other.bitV[0] ;
+    r.bitV[1] = this->bitV[1] ^ other.bitV[1] ;
+    return r ;
+  }
+
+
+  inline BitVec64x2 operator+ (const BitVec64x2& other) const {
+    BitVec64x2 r ;
+    r.bitV[0] = this->bitV[0] + other.bitV[0] ;
+    r.bitV[1] = this->bitV[1] + other.bitV[1] + (r.bitV[0] < this->bitV[0]) ;
+    return r ;
+  }
+
+
+  static bool isQueryLengthOk(int qlen) {
+    return qlen <= 127 ;
+  }
+
+  friend std::ostream& operator<< (std::ostream& os, const BitVec64x2& b) {
+    os << "{" << b.bitV[0] << ", " << b.bitV[1] << "}" ;
+    return os ;
+  }
+
+  friend class EDVec64x2 ;
+  friend class EDVec128Every16 ;
+} ;
+
+
+
+#endif // #ifndef _FAST_EXTEND_BITV64x2_H

--- a/intel_opt/fast_extend_dist.h
+++ b/intel_opt/fast_extend_dist.h
@@ -1,0 +1,86 @@
+/* 
+The MIT License (MIT)
+Copyright (c) 2014 Intel Corp.
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef _FAST_EXTEND_DIST_H
+#define _FAST_EXTEND_DIST_H
+
+//
+// This class handles the distance computations by reading the probes at BitVec, and
+// storing the computed distance values in EDVec.
+//
+template<class BitVec, class EDVec>
+class DistVec {
+
+  EDVec dist_, mask_ ;
+  BitVec probeShiftCnt_ ;
+  int queryLen_, msWordIndex_, probeOffset_ ;
+  
+ public: 
+  
+ DistVec(int queryLen):
+  queryLen_(queryLen), msWordIndex_(EDVec::getLastWordIndexFor(queryLen)),
+    probeOffset_(EDVec::getProbeOffsetFor(queryLen)) {
+
+    probeShiftCnt_.setAll64BitWords(probeOffset_+1) ;
+    mask_.setWordsAsMask() ;
+  }
+
+  const EDVec& getVec() const {
+    return dist_ ;
+  }
+
+  void initDist(int initU0, int initU1) {
+    dist_.setWordsAsDist(queryLen_, initU0 - initU1) ;
+  }
+
+  void addDist (const BitVec& LP0, const BitVec& LP1) {
+ 
+    dist_ += (EDVec(LP0.shiftProbesRight(probeOffset_, probeShiftCnt_)) & mask_) ;
+    dist_ -= (EDVec(LP1.shiftProbesRight(probeOffset_, probeShiftCnt_)) & mask_) ;
+  }
+
+  EDVec getDeltaDistVec(const BitVec& LP0, const BitVec& LP1) {
+    EDVec r = EDVec(LP0.shiftProbesRight(probeOffset_, probeShiftCnt_)) & mask_ ;
+    r -= EDVec(LP1.shiftProbesRight(probeOffset_,probeShiftCnt_)) & mask_ ;
+
+    return r ;
+  }
+
+  void addDist (const EDVec& deltaDist) {
+    dist_ += deltaDist ;
+  }
+
+  int getValidDistCnt() const {
+    return msWordIndex_ + 1 ;
+  }
+
+  int getProbeColumn(int index) const {
+    return EDVec::getDistAt(index, queryLen_) - 1 ;
+  }
+
+  int getDist(int index) const {
+    return (int) dist_.getWord(index) ;
+  }
+
+  int getTotalDist() const {
+    return (int) dist_.getWord(msWordIndex_) ;
+  }
+
+  void setMin (const DistVec& other) {
+    this->dist_.setMin(other.dist_) ;
+  }
+
+  friend std::ostream& operator<< (std::ostream& os, const DistVec& d) {
+    os << d.dist_ ;
+    return os ;
+  }
+
+} ;
+
+
+#endif // #ifndef _FAST_EXTEND_DIST_H

--- a/intel_opt/fast_extend_engine.cpp
+++ b/intel_opt/fast_extend_engine.cpp
@@ -1,0 +1,1247 @@
+/* 
+The MIT License (MIT)
+Copyright (c) 2014 Intel Corp.
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include <iostream>
+#include <stdint.h>
+#include <assert.h>
+#include <stdlib.h>
+
+#ifdef USE_AVX2
+#include "fast_extend_vec256.h"
+#include "fast_extend_bitv256.h"
+#endif
+
+#include "fast_extend_vec128x2.h"
+#include "fast_extend_vec128.h"
+#include "fast_extend_vec64.h"
+#include "fast_extend_vec32.h"
+#include "fast_extend_bitv64.h"
+#include "fast_extend_bitv64x2.h"
+#include "fast_extend_bitv128.h"
+#include "fast_extend_bitv128x2.h"
+#include "fast_extend_fine.h"
+#include "fast_extend_dist.h"
+#include "fast_extend.h"
+
+// Perform fine-grain alignment because it improves quality of cases with very short extension
+#define FINE_ALIGN
+
+//#define DEBUG0
+//#define DEBUG1
+//#define DEBUG2
+
+//#ifdef SW_FILTER_AND_EXTEND
+//#define SW_FEEDBACK 
+//#endif
+#define SW_FILTER_AND_EXTEND
+#define SW_FEEDBACK
+
+extern "C" {
+int ksw_extend(int qlen, const uint8_t *query, int tlen, const uint8_t *target, int m, const int8_t *mat, int gapo, int gape, int w, int end_bonus, int zdrop, int h0, int *qle, int *tle, int *gtle, int *gscore, int *max_off);
+}
+
+const int defaultCostMatrixRowCnt = 5 ;
+
+const int8_t defaultCostMatrix[] = {
+  1, -4, -4, -4, -1,
+  -4,  1, -4, -4, -1,
+  -4, -4,  1, -4, -1,
+  -4, -4, -4,  1, -1,
+  -1, -1, -1, -1, -1 
+} ;
+
+struct SWFeedback {
+  int maxQLen ;
+  int maxRLen ;
+  int maxBand ;
+  int minQLen ;
+  int minRLen ;
+  int minScore ;
+
+  SWFeedback():maxQLen(0), maxRLen(0), maxBand(0), minQLen(0), minRLen(0), minScore(0) {} ;
+
+  SWFeedback(int qlen, int rlen, int band, int origQLen, int origRLen)
+    : maxQLen(qlen), maxRLen(rlen), maxBand(band), 
+      minQLen(origQLen), minRLen(origRLen), minScore(0) {}
+
+  void updateMax(int qlen, int rlen, int band) {
+    maxQLen = qlen ;
+    maxRLen = rlen ;
+    maxBand = band ;
+  }
+
+  void updateMin(int currQLen, int currRLen, int currScore) {
+    minQLen = currQLen ;
+    minRLen = currRLen ;
+    minScore = currScore ;
+  }
+} ;
+
+inline ostream& operator<<(ostream& os, const SWFeedback& swfb) {
+  os << "{"  << swfb.minQLen << ":" << swfb.maxQLen << ", " << swfb.minRLen << ":"
+     << swfb.maxRLen << " " << swfb.maxBand << " " << swfb.minScore << "}" << endl ;
+  return os ;
+}
+
+struct PartialAlignment {
+  int partialQLen, partialRLen ;
+  int scoreLow, scoreHigh ;
+#ifdef SW_FEEDBACK
+  int estimatedBand ;
+#endif
+  
+  PartialAlignment() {}
+  PartialAlignment(int qlen, int rlen, int scoreL, int scoreH)
+    : partialQLen(qlen), partialRLen(rlen), scoreLow(scoreL), scoreHigh(scoreH) {
+#ifdef SW_FEEDBACK
+    estimatedBand = 0 ;
+#endif
+  }
+
+} ;
+
+inline ostream& operator<<(ostream& os, const PartialAlignment& align) {
+  cerr << "Partial alignment (" << align.partialQLen << ", " << align.partialRLen 
+       << "): score = [" << align.scoreLow << ", " << align.scoreHigh << "]"
+#ifdef SW_FEEDBACK
+       << ", estimatedBand = " << align.estimatedBand
+#endif
+    ;
+  return os ;
+}
+
+
+// Calls the original ksw_extend function
+int run_ksw_extend(const uint8_t* refSeq, int refLen, const uint8_t* querySeq, int queryLen,
+		   int bandW, int initScore, int endBonus, int zdrop, int costMatrixRowCnt,
+		   const int8_t* costMatrix, int gapo, int gape,
+		   int& alignedQLen, int& alignedRLen) {
+
+  int qle, tle, gtle, gscore, max_off ;
+
+  int pscore = 0 ;
+
+  if (bandW < 8) 
+    pscore = ksw_extend_sse_8(queryLen, querySeq, refLen, refSeq, costMatrixRowCnt, costMatrix,
+			    gapo, gape, bandW, endBonus, zdrop, initScore,
+			    &qle, &tle, &gtle, &gscore, &max_off) ;
+    
+  else if (bandW < 16) 
+    pscore = ksw_extend_16(queryLen, querySeq, refLen, refSeq, costMatrixRowCnt, costMatrix,
+			     gapo, gape, bandW, endBonus, zdrop, initScore,
+			     &qle, &tle, &gtle, &gscore, &max_off) ;
+  
+  else if (bandW < 32) {
+    pscore = ksw_extend_32(queryLen, querySeq, refLen, refSeq, costMatrixRowCnt, costMatrix,
+				gapo, gape, bandW, endBonus, zdrop, initScore,
+				&qle, &tle, &gtle, &gscore, &max_off) ;
+
+  }else { // if no vectorized solution exists, run the serial function 
+    pscore = ksw_extend(queryLen, querySeq, refLen, refSeq, costMatrixRowCnt, costMatrix,
+			gapo, gape, bandW, endBonus, zdrop, initScore,
+			&qle, &tle, &gtle, &gscore, &max_off) ;
+  }
+
+
+  if (gscore <= 0 || gscore <= pscore - endBonus) {
+    alignedQLen = qle ;
+    alignedRLen = tle ;
+    return pscore ;
+  }
+  else {
+    alignedQLen = queryLen ;
+    alignedRLen = gtle ;
+    return gscore ;
+  }
+}
+
+// Function used to pack query bits into uint64_t
+inline void orBitAtPosition(uint64_t& w, bool newBit, int index) {
+  w |= (((uint64_t)newBit) << index) ;
+}
+
+template<class BitVec>
+inline BitVec computeMatchVec(const BitVec& Q0, const BitVec& Q1, const BitVec& Q2,
+			      const BitVec& R0, const BitVec& R1, const BitVec& R2) {
+  return ~Q2 & ~R2 & ((Q1 ^ R1) | (Q0 ^ R0)) ;
+}
+
+// This can be made faster if needed
+int computeHammingDistance(const uint8_t* refSeq, int refLen, const uint8_t* querySeq, int queryLen, int upperBound, int& lastConsecutiveMatching) {
+  
+  int cnt = min(refLen, queryLen) ;
+  int dist = 0 ;
+  lastConsecutiveMatching = 0 ;
+  for (int ci=0; ci < cnt; ++ci) {
+
+    ++lastConsecutiveMatching ;
+    if (refSeq[ci] != querySeq[ci]) {
+      ++dist ;
+      lastConsecutiveMatching = 0 ;
+      if (dist >= upperBound)
+	return dist ;
+    }
+  }
+
+  return dist ;
+}
+
+inline bool isHammingDistanceSmallEnough(const uint8_t* refSeq, int refLen, const uint8_t* querySeq, int queryLen,
+					 int& alignedQLenLow, int& alignedQLenHigh,
+					 int& alignedRLenLow, int& alignedRLenHigh,
+					 int& maxScoreLow, int& maxScoreHigh,
+					 int mismatchWt, int gapOpenWt) {
+
+	int minSeqLen = std::min(refLen, queryLen) ;
+
+  // This heuristic is applicable to only queries that are long enough (e.g. >= 20 bases)
+  if (minSeqLen < 20)
+    return false ;
+
+  // If there is a mismatch towards the end of the query, it is possible that partial
+  // alignment is better than full alignment. So, the last consecutive match is returned in the
+  // function below.
+  int lastConsecutiveMatching=0 ;
+  
+  // If Hamming dist is greater than upper bound, no need to process the whole query
+  // The value below can be tuned.
+  int upperBound = minSeqLen / gapOpenWt ; 
+  
+  int hdist = computeHammingDistance(refSeq, refLen, querySeq, queryLen, upperBound, lastConsecutiveMatching) ;
+    
+  // If lastConsecutiveMatching is <= gapOpenWt, we don't have high confidence in
+  // full alignment. 
+  if (hdist < upperBound && lastConsecutiveMatching > gapOpenWt) {
+#ifdef DEBUG0
+    cerr << "The Hamming distance is " << hdist  << " with " << lastConsecutiveMatching
+	 << " bases matches at the end of query. " << endl ;
+    cerr << "Returning full alignment directly." << endl ;
+#endif
+    alignedQLenLow = alignedQLenHigh = minSeqLen ;
+    alignedRLenLow = alignedRLenHigh = minSeqLen ;
+    maxScoreLow = maxScoreHigh = (minSeqLen - hdist) - hdist * mismatchWt ;
+    
+    return true ;
+  }
+
+  return false ;
+}
+				  
+
+template<class BitVec, class EDVec>
+void fast_extend(const uint8_t* refSeq, int refLen, const uint8_t* querySeq, int queryLen,
+		 int initScore, int endBonus, 
+		 int& alignedQLenLow, int& alignedQLenHigh,
+		 int& alignedRLenLow, int& alignedRLenHigh,
+		 int& maxScoreLow, int& maxScoreHigh, SWFeedback& swfb,
+		 int mismatchWt=4, int gapWt=1, int gapOpenWt=6, int ambigWt = 1) {
+
+
+  assert (BitVec::isQueryLengthOk(queryLen)) ;
+
+#ifdef DEBUG0
+  cerr << "Query and ref lens for SW problem: " << queryLen << " " << refLen << endl ;
+#endif
+
+  // If full alignment is obvious, return immediately
+  if (isHammingDistanceSmallEnough(refSeq, refLen, querySeq, queryLen,
+																	 alignedQLenLow, alignedQLenHigh, 
+																	 alignedRLenLow, alignedRLenHigh,
+																	 maxScoreLow, maxScoreHigh,
+																	 mismatchWt, gapOpenWt)) {
+		maxScoreLow += initScore;
+		maxScoreHigh += initScore;
+    return ;
+  }
+
+  // Define the bit vectors that will be used in fast edit distance computation
+  BitVec L0, L1, U0, U1, UP0, UP1 ;
+  BitVec Q0, Q1, Q2 ;
+  BitVec D[5] ; // profile vecs
+
+  bool initL0 = 1 ; 
+  bool initL1 = 0 ;
+
+  bool initU0 = 1 ;
+  bool initU1 = 0 ;
+
+#ifdef FINE_ALIGN
+  const int FINE_ALIGN_CNT = 16 ; // align the first 16 bases in a fine-grain way
+  assert (FINE_ALIGN_CNT <= 16) ; // the rest of the code assumes this.
+  int ambigBaseCntsFineArr[FINE_ALIGN_CNT] ;
+  for (int i=0; i < FINE_ALIGN_CNT; ++i)
+    ambigBaseCntsFineArr[i] = 0 ;
+#endif
+
+  // Keep track of the ambig bases corresponding to each score probe
+  EDVec ambigBaseCnts(0) ;
+  int ambigBaseCntsArr[EDVec::WORD_CNT()] ;
+  for (int i=0; i < EDVec::WORD_CNT(); ++i)
+    ambigBaseCntsArr[i] = 0 ;
+  int ambigWordIndex = 0 ;
+
+  // Store the query in bit vectors
+  for (int wIndex=0; wIndex * 64 < queryLen; ++wIndex) {
+    uint64_t bit0Partial = 0x0 ;
+    uint64_t bit1Partial = 0x0 ;
+    uint64_t bit2Partial = 0x0 ;
+
+    for (int bIndex=0; bIndex < 64; ++bIndex) {
+      int qi = wIndex * 64 + bIndex ;
+      if (qi >= queryLen)
+	break ;
+      uint8_t qbase = querySeq[qi] ;
+      if (qbase == 4) {
+
+	while (qi >= EDVec::getDistAt(ambigWordIndex, queryLen))
+	  ++ambigWordIndex ;
+	++ambigBaseCntsArr[ambigWordIndex] ;
+
+#ifdef FINE_ALIGN
+	if (qi < FINE_ALIGN_CNT)
+	  ++ambigBaseCntsFineArr[qi] ;
+#endif
+      }
+
+      orBitAtPosition(bit0Partial, qbase & 0x1, bIndex) ;
+      orBitAtPosition(bit1Partial, (qbase & 0x2) >> 1, bIndex) ;
+      orBitAtPosition(bit2Partial, (qbase & 0x4) >> 2, bIndex) ;
+    }
+    Q0.setWord(wIndex, bit0Partial) ;
+    Q1.setWord(wIndex, bit1Partial) ;
+    Q2.setWord(wIndex, bit2Partial) ;
+  }
+  
+  
+  // Compute running sum of ambig base cnts
+  for (int wi=1; wi < EDVec::WORD_CNT(); ++wi) {
+    ambigBaseCntsArr[wi] += ambigBaseCntsArr[wi-1] ;
+  }
+  ambigBaseCnts.setWords(ambigBaseCntsArr) ;
+  
+
+#ifdef FINE_ALIGN
+  for (int wi=1; wi < FINE_ALIGN_CNT; ++wi) {
+    ambigBaseCntsFineArr[wi] += ambigBaseCntsFineArr[wi-1] ;
+  }
+#endif
+
+  // pre-compute the profile vectors
+  BitVec B0, B1 ;
+  B0.setAllZeroes() ;
+  B1.setAllOnes() ;
+  
+  D[0] = computeMatchVec(Q0, Q1, Q2, B0, B0, B0) ;
+  D[1] = computeMatchVec(Q0, Q1, Q2, B1, B0, B0) ;
+  D[2] = computeMatchVec(Q0, Q1, Q2, B0, B1, B0) ;
+  D[3] = computeMatchVec(Q0, Q1, Q2, B1, B1, B0) ;
+  D[4] = computeMatchVec(Q0, Q1, Q2, B0, B0, B1) ;
+  
+
+  // Initialize boundary conditions
+  BitVec initL0Vec, initL1Vec ;
+  initL0Vec.setLSBClearRest(initL0) ;
+  initL1Vec.setLSBClearRest(initL1) ;
+
+  U0.setAllBits(initU0) ;
+  U1.setAllBits(initU1) ;
+
+  // Init the edit distance vec.
+  DistVec<BitVec,EDVec> accumDist(queryLen) ;
+  accumDist.initDist(initU0, initU1) ;
+
+#ifdef SW_FEEDBACK
+  EDVec bestAccumDist = accumDist.getVec() ;
+#endif
+
+  int INF_SCORE = EDVec::getMaxWordVal() ;
+
+  EDVec currColVec(0) ;
+  EDVec bestScore(0), bestColVec(0) ;
+
+  EDVec queryLenVec ;
+  queryLenVec.setWordsAsDist(queryLen, 1) ;
+
+#ifdef FINE_ALIGN
+  FineAlignment16 fineAlign(queryLen, endBonus, mismatchWt, ambigWt) ;
+#endif
+
+  EDVec mismatchWtP1Vec(mismatchWt+1), // P1: plus 1
+    gapWtVec(gapWt), gapWtP1Vec(gapWt+1), gapOpenWtVec(gapOpenWt), ambigWtP1Vec(ambigWt+1), 
+    zeroVec(0) ;
+  
+  EDVec endBonusVec(0), deltaScoreVec(initScore), badScoreVec(0) ;
+  endBonusVec.setWordsAsEndBonus(queryLen, endBonus) ;
+  deltaScoreVec = deltaScoreVec + queryLenVec - ambigBaseCnts * ambigWtP1Vec + endBonusVec ;
+  badScoreVec.setWordsAsBadScore(queryLen, 0, INF_SCORE) ;
+
+  // Every time the edit distance is increased by 1, we add -(mismatchWt+1) to score.
+  // For an INSERT (downwards move) in the lower-triangle part of the matrix:
+  //       * Increasing column index means reducing the insert count. This should increase score
+  //         by (gapWt+1), i.e. replacing one insertion by one match.
+  //       * However, if this change is not reflected in the edit distance, this means that
+  //         the insertion was replaced by a mismatch.
+  //       * So, the delta cost for INSERT is: (gapWt+1) - (mismatchWt+1) = gapWt - mismatchWt
+  // 
+  // For a DELETE (right move) in the upper-triangle part of the matrix:
+  //       * Increasing column index means increasing the delete count. This should decrease score
+  //         by gapWt.
+  //       * However, we also pay for mismatch cost of (mismatchWt+1), assuming that edit dist has
+  //         increased by 1. We should not pay for this mismatch cost.
+  //       * So, the delta cost for DELETE is: -gapWt + (mismatchWt+1)
+
+  EDVec deltaCostInsert((gapWt-mismatchWt)) ; // insert costs decrease as ci increases
+
+  EDVec deltaCostDelete(0) ; // delete costs increase as ci increases
+  EDVec deltaCostDistWt(-(mismatchWt+1)) ;
+  EDVec deltaColVec(1) ;
+  
+  EDVec insertVecModifier(0), deleteVecModifier(0), gapOpenDelta(0) ;
+  insertVecModifier.setFirstWord(-(gapWt-mismatchWt)) ; // will cancel one entry when added
+  deleteVecModifier.setFirstWord(-gapWt + mismatchWt + 1) ; // will add deleteWt to one entry
+  gapOpenDelta.setFirstWord(gapOpenWt) ; // will remove/add gapOpenWt from/to one diag entry
+
+  EDVec firstColCost = deltaScoreVec - queryLenVec * gapWtP1Vec - gapOpenWtVec ;
+
+  EDVec currScore = firstColCost ;
+  EDVec deltaMismatch(0) ;
+
+#ifdef DEBUG1
+  cerr << " The init score is: " << initScore << endl ;
+  cerr << " The cost of the 0th column: " << firstColCost << endl ;
+#endif
+
+  // Score is computed as follows:
+  // (Note that ambigCnt and gapCnt are NOT included in editDist.)
+  // (If the gap type is deletion and there are ambig bases in query, the score estimated
+  //  is lower than the actual score. Some of the ambig bases may be skipped in deletions, but
+  //  we don't capture this. This can be fixed later by subtracting delete-cnt from ambigCnt
+  //  at every column less than qlen.)
+  // score =  (qlen - editDist - ambigCnt - insertCnt) // score corresponding to matches
+  //          - ambigCnt * ambigWt // score corresponding to ambig bases
+  //          - (deleteCnt+insertCnt) * gapWt // score corresponding to gap extends
+  //          - editDist * mismatchWt // score corresponding to mismatches
+  // Reordering the constant terms, we have:
+  // score =  - insertCnt * (gapWt+1)     // variable term
+  //          - deleteCnt * gapWt         // variable term
+  //          - editDist * (mismatchWt+1) // variable term
+  //          + qlen - ambigCnt * (ambigWt+1) // constant terms
+
+
+#define PRINT_UPDATE_COST_DEBUG(__ci) {					\
+    cerr << "In iteration " << __ci << ", the cost values are updated to:" << endl ; \
+    cerr << "L0: " << std::hex << L0 << std::dec << endl ;		\
+    cerr << "L1: " << std::hex << L1 << std::dec << endl ;		\
+    cerr << "currColVec: " << currColVec << endl ;			\
+    cerr << "queryLenVec: " << queryLenVec << endl ;			\
+    cerr << "deltaCostInsert: " << deltaCostInsert << endl ;	        \
+    cerr << "deltaCostDelete: " << deltaCostDelete << endl ;      	\
+    cerr << "deltaMismatch: " << deltaMismatch << endl ;		\
+    cerr << "deltaCostDistWt: " << deltaCostDistWt << endl ;		\
+    cerr << "currScore: " << currScore << endl ;			\
+    cerr << "bestCol: " << bestColVec << endl ;				\
+    cerr << "bestScore: " << bestScore << endl ;			\
+  }
+
+#define PRINT_DELTA_MODIFICATIONS_DEBUG(__ci) {			       \
+    cerr << "The delta costs have been updated after processing column " << __ci << endl ; \
+    cerr << "New delta cost insert: " << deltaCostInsert << endl ;	\
+    cerr << "New delta cost delete: " << deltaCostDelete << endl ;	\
+    cerr << "using the modifiers: " << endl ;				\
+    cerr << "Insert vec modifier: " << insertVecModifier << endl ;	\
+    cerr << "Delete vec modifier: " << deleteVecModifier << endl ;	\
+  }
+
+
+#define COMPUTE_LU(__ci) {			\
+    uint8_t refChar = refSeq[ci] ;		\
+    const BitVec& currD = D[refChar] ;		\
+    BitVec SL1 = U0.andnot(currD) ;		\
+    SL1.shiftLeftAndInsert(initL1) ;		\
+						\
+    BitVec INJ = U0 & SL1 ;			\
+    BitVec SUM = INJ + U0 ;			\
+    BitVec CIN = SUM ^ INJ ^ U0 ;		\
+						\
+    L1 = SL1 | CIN ;				\
+    L0 = U1 | currD.andnot(L1).andnot(U0) ;	\
+    L0.shiftLeftAndInsert(initL0) ;		\
+						\
+    BitVec TU = currD.andnot(U1) ;		\
+    U1 = L0.andnot(TU) ;			\
+    U0 = L1 | TU.andnot(L0) ;			\
+						\
+    /* Add delta costs corresponding to the current mismatch delta (-1, 0, or 1) */ \
+    deltaMismatch = accumDist.getDeltaDistVec(L0, L1) ;			\
+    accumDist.addDist(deltaMismatch) ;					\
+    									\
+  }
+
+#define UPDATE_COSTS(__ci) {						\
+    currColVec += deltaColVec ;						\
+    EDVec gapDelta = deltaCostInsert + deltaCostDelete ;		\
+    /*gapDelta.addThirdIfFirstGTSecond(gapDelta, zeroVec, gapOpenWtVec, zeroVec) ; */ \
+    currScore += gapDelta ;						\
+									\
+    currScore += (deltaMismatch * deltaCostDistWt) ;			\
+    bestScore.setMax(currScore, bestColVec, currColVec) ;		\
+  }
+
+#define UPDATE_COSTS_AND_CHECK(__ci) {					\
+    currColVec += deltaColVec ;						\
+    EDVec gapDelta = deltaCostInsert + deltaCostDelete ;		\
+    /*gapDelta.addThirdIfFirstGTSecond(gapDelta, zeroVec, gapOpenWtVec, zeroVec) ; */ \
+    currScore += gapDelta ;						\
+									\
+    /* Add delta costs corresponding to the current mismatch delta (-1, 0, or 1) */  \
+    deltaMismatch = accumDist.getDeltaDistVec(L0, L1) ;			\
+									\
+    currScore += (deltaMismatch * deltaCostDistWt) ;			\
+    updateFlag |= bestScore.setMaxAndReturnFlag(currScore, bestColVec, currColVec) ; \
+  }
+
+#define UPDATE_COSTS_AND_STORE_BEST_ACCUM_DIST(__ci) {			\
+    currColVec += deltaColVec ;						\
+    EDVec gapDelta = deltaCostInsert + deltaCostDelete ;		\
+    /*gapDelta.addThirdIfFirstGTSecond(gapDelta, zeroVec, gapOpenWtVec, zeroVec) ; */ \
+    currScore += gapDelta ;						\
+									\
+    /* Add delta costs corresponding to the current mismatch delta (-1, 0, or 1) */  \
+    deltaMismatch = accumDist.getDeltaDistVec(L0, L1) ;			\
+									\
+    currScore += (deltaMismatch * deltaCostDistWt) ;			\
+    bestScore.setMax(currScore, bestColVec, currColVec, bestAccumDist, accumDist.getVec()) ; \
+  }
+
+#define UPDATE_COSTS_AND_CHECK_AND_STORE_BEST_ACCUM_DIST(__ci) {	\
+    currColVec += deltaColVec ;						\
+    EDVec gapDelta = deltaCostInsert + deltaCostDelete ;		\
+    /*gapDelta.addThirdIfFirstGTSecond(gapDelta, zeroVec, gapOpenWtVec, zeroVec) ; */ \
+    currScore += gapDelta ;						\
+									\
+    /* Add delta costs corresponding to the current mismatch delta (-1, 0, or 1) */  \
+    deltaMismatch = accumDist.getDeltaDistVec(L0, L1) ;		\
+									\
+    currScore += (deltaMismatch * deltaCostDistWt) ;			\
+    updateFlag |= bestScore.setMaxAndReturnFlag(currScore, bestColVec, currColVec, bestAccumDist, accumDist.getVec()) ; \
+  }
+
+
+#define REMOVE_GAP_OPEN_PENALTY_FOR_DIAG(__ci) {			\
+    currScore += gapOpenDelta ;						\
+  }
+
+#define ADD_GAP_OPEN_PENALTY_TO_DIAG(__ci) {				\
+    currScore -= gapOpenDelta ;						\
+    									\
+    /* shift the modifier so that they modify the next lane in the next update */ \
+    gapOpenDelta.shiftWordsLeftByOne() ;				\
+  }
+
+#define PERFORM_DELTA_MODIFICATIONS(__ci) {				\
+    deltaCostInsert += insertVecModifier ;				\
+    deltaCostDelete += deleteVecModifier ;				\
+    									\
+    /* shift the modifiers so that they modify the next lane in the next update */ \
+    insertVecModifier.shiftWordsLeftByOne() ;				\
+    deleteVecModifier.shiftWordsLeftByOne() ;				\
+    									\
+  }
+
+#define UPDATE_FINE_ALIGN(__ci) {		\
+    if (__ci < FINE_ALIGN_CNT)						\
+      fineAlign.update(U0.getLow16Bits(), U1.getLow16Bits(), __ci+1,	\
+		       ambigBaseCntsFineArr[__ci]) ;			\
+    									\
+  }
+
+#define CHECK_TERMINATION(__ci) {				\
+    if (currScore.allLessThanOrEqualTo(badScoreVec)) {		\
+      goto loopEnd ;						\
+    }								\
+  }
+
+#define CHECK_COSTS(__ci) {						\
+    EDVec deleteCntVec = currColVec.subSat(queryLenVec) ;		\
+    EDVec insertCntVec = queryLenVec.subSat(currColVec) ;		\
+    EDVec gapCntVec = insertCntVec + deleteCntVec ;			\
+									\
+    EDVec gapPenaltyVec = gapCntVec * gapWtVec + insertCntVec ;		\
+    gapPenaltyVec.addThirdIfFirstGTSecond(gapCntVec, zeroVec, gapOpenWtVec, zeroVec) ; \
+									\
+    EDVec currScoreVecTest =						\
+      deltaScoreVec - gapPenaltyVec - accumDist.getVec() * mismatchWtP1Vec ; \
+    EDVec currScoreVecTest =						\
+      deltaScoreVec - gapPenaltyVec - accumDist.getVec() * mismatchWtP1Vec ;	\
+									\
+    if (!(currScoreVecTest == currScore) || !(currScoreVecTest == currScore)) { \
+      cerr << "Error: Mismatch in cost values computed using two methods at column " << ci << endl ; \
+      cerr << "deleteCntVec: " << deleteCntVec << endl ;		\
+      cerr << "insertCntVec: " << insertCntVec << endl ;		\
+      cerr << "gapPenaltyVec: " << gapPenaltyVec << endl ;		\
+      cerr << "score (test): " << currScoreVecTest << endl ;		\
+      exit(0) ;								\
+    }									\
+  }
+
+  // If there are 3 words in EDVec, flagMask will be 0....0111111 in binary.
+  // The flagMask has 2 bits per word, because of SSE limitations.
+  uint32_t flagMask = (uint32_t) ((((uint64_t)1) << (2*(EDVec::getLastWordIndexFor(queryLen)+1))) - 1) ;
+
+  int firstProbeOffset = min(refLen-1, accumDist.getProbeColumn(0)) ;
+  int numFullIters ;
+  
+  int ci = 0 ;
+  for (; ci < firstProbeOffset; ++ci) {
+    COMPUTE_LU(ci) ;
+
+#ifdef SW_FEEDBACK
+    UPDATE_COSTS_AND_STORE_BEST_ACCUM_DIST(ci) ;
+#else
+    UPDATE_COSTS(ci) ;
+#endif
+
+#ifdef FINE_ALIGN
+    UPDATE_FINE_ALIGN(ci) ;
+#endif
+#ifdef DEBUG1
+    PRINT_UPDATE_COST_DEBUG(ci) ;
+#endif
+    //CHECK_COSTS(ci) ;
+  }
+  
+  REMOVE_GAP_OPEN_PENALTY_FOR_DIAG(ci) ;
+  
+  if (firstProbeOffset >= 0) {
+    COMPUTE_LU(ci) ;
+
+#ifdef SW_FEEDBACK
+    UPDATE_COSTS_AND_STORE_BEST_ACCUM_DIST(ci) ;
+#else
+    UPDATE_COSTS(ci) ;
+#endif
+
+#ifdef FINE_ALIGN
+    UPDATE_FINE_ALIGN(ci) ;
+#endif
+#ifdef DEBUG1
+    PRINT_UPDATE_COST_DEBUG(ci) ;
+#endif
+    //CHECK_COSTS(ci) ;
+    ++ci ; 
+  }
+  ADD_GAP_OPEN_PENALTY_TO_DIAG(ci-1) ;
+
+  PERFORM_DELTA_MODIFICATIONS(ci-1) ;
+#ifdef DEBUG1
+  PRINT_DELTA_MODIFICATIONS_DEBUG(ci-1) ;
+#endif
+  CHECK_TERMINATION(ci-1) ;
+
+
+	numFullIters = (min(queryLen, refLen)-ci) /EDVec::PERIOD() ;
+  for (int iterIndex = 0; iterIndex < numFullIters; ++iterIndex) {
+
+    for (int subIterIndex=0; subIterIndex < EDVec::PERIOD()-1; ++subIterIndex, ++ci) {
+      COMPUTE_LU(ci) ;
+#ifdef SW_FEEDBACK
+    UPDATE_COSTS_AND_STORE_BEST_ACCUM_DIST(ci) ;
+#else
+    UPDATE_COSTS(ci) ;
+#endif
+
+#ifdef FINE_ALIGN
+      UPDATE_FINE_ALIGN(ci) ;
+#endif
+#ifdef DEBUG1
+      PRINT_UPDATE_COST_DEBUG(ci) ;
+#endif
+      //CHECK_COSTS(ci) ;
+    }
+    REMOVE_GAP_OPEN_PENALTY_FOR_DIAG(ci) ;
+    COMPUTE_LU(ci) ;
+
+#ifdef SW_FEEDBACK
+    UPDATE_COSTS_AND_STORE_BEST_ACCUM_DIST(ci) ;
+#else
+    UPDATE_COSTS(ci) ;
+#endif
+
+#ifdef FINE_ALIGN
+    UPDATE_FINE_ALIGN(ci) ;
+#endif
+#ifdef DEBUG1
+    PRINT_UPDATE_COST_DEBUG(ci) ;
+#endif
+    //CHECK_COSTS(ci) ;
+    ADD_GAP_OPEN_PENALTY_TO_DIAG(ci) ;
+
+    PERFORM_DELTA_MODIFICATIONS(ci) ;
+#ifdef DEBUG1
+    PRINT_DELTA_MODIFICATIONS_DEBUG(ci) ;
+#endif
+
+    CHECK_TERMINATION(ci) ;
+    ++ci ;
+  }
+
+
+  // If there are 3 words in EDVec, flagMask will be 0....0111111 in binary
+  // flagMask has 2 bits per word, because of SSE limitations
+
+  // Next, process the columns with indices greater than or equal to query length
+  numFullIters = (refLen-ci) / EDVec::PERIOD() ;
+  for (int iterIndex = 0; iterIndex < numFullIters; ++iterIndex) {
+    uint32_t updateFlag = 0x0 ; // 2 bits per word, because of SSE limitations
+
+    for (int subIterIndex=0; subIterIndex < EDVec::PERIOD(); ++subIterIndex, ++ci) {
+      COMPUTE_LU(ci) ;
+
+#ifdef SW_FEEDBACK
+      UPDATE_COSTS_AND_CHECK_AND_STORE_BEST_ACCUM_DIST(ci) ;
+#else
+      UPDATE_COSTS_AND_CHECK(ci) ;
+#endif
+
+
+#ifdef DEBUG1
+      PRINT_UPDATE_COST_DEBUG(ci) ;
+#endif
+      //CHECK_COSTS(ci) ; // will fail for the padded entries
+    }
+
+    updateFlag &= flagMask ;
+
+    if (!updateFlag) // if the best score hasn't been updated in any iteration
+      goto loopEnd ;
+
+    CHECK_TERMINATION(ci) ;
+  }
+
+
+  // Next, process the remaining columns
+  for (; ci < refLen; ++ci) {
+    COMPUTE_LU(ci) ;
+
+#ifdef SW_FEEDBACK
+    UPDATE_COSTS_AND_STORE_BEST_ACCUM_DIST(ci) ;
+#else
+    UPDATE_COSTS(ci) ;
+#endif
+
+#ifdef DEBUG1
+    PRINT_UPDATE_COST_DEBUG(ci) ;
+#endif
+    // CHECK_COSTS(ci) ; // will fail for the padded entries
+  }
+
+ loopEnd:
+#ifdef DEBUG0
+  if (ci < refLen)
+    cerr << "Loop terminated after iteration " << ci << endl ;
+#endif
+
+  PartialAlignment partials[EDVec::WORD_CNT()+2] ;
+
+  // no alignment
+  partials[0] = PartialAlignment(0, 0, initScore, initScore) ;
+  maxScoreHigh = initScore ;
+  maxScoreLow = initScore ;
+
+#ifdef SW_FEEDBACK
+  partials[0].estimatedBand = 0 ;
+#endif
+
+  int partialCnt = 1 ;
+
+#ifdef FINE_ALIGN
+  // result of fine_align
+  int alignedLenFine, scoreFine ;
+  fineAlign.getBest(alignedLenFine, scoreFine) ;
+  scoreFine += initScore ;
+  partials[1] = PartialAlignment(alignedLenFine, alignedLenFine, scoreFine, scoreFine) ;
+#ifdef SW_FEEDBACK
+  partials[1].estimatedBand = 1 ;
+#endif
+
+  if (scoreFine > maxScoreHigh) {
+    maxScoreHigh = scoreFine ;
+  }
+  if (scoreFine > maxScoreLow) {
+    maxScoreLow = scoreFine ;
+  }
+
+  ++partialCnt ;
+#endif // #ifdef FINE_ALIGN
+
+  for (int di=0; di < accumDist.getValidDistCnt(); ++di) {
+    int currQLen = queryLenVec.getWord(di) ;
+    int currRLen = bestColVec.getWord(di) ;
+    int currScoreHigh = bestScore.getWord(di) ;
+    
+    int gapCnt = abs(currQLen - currRLen) ;
+
+    int currScoreLow = (gapCnt == 0) ? currScoreHigh :
+      (currScoreHigh - gapCnt * (mismatchWt - gapWt) + gapOpenWt) ;
+
+    if (currScoreHigh > maxScoreHigh) {
+      maxScoreHigh = currScoreHigh ;
+    }
+    if (currScoreLow > maxScoreLow) {
+      maxScoreLow = currScoreLow ;
+    }
+
+    partials[partialCnt] = PartialAlignment(currQLen, currRLen, currScoreLow, currScoreHigh) ;
+
+#ifdef SW_FEEDBACK
+    int currEditDist = bestAccumDist.getWord(di) ;
+    partials[partialCnt].estimatedBand = gapCnt + max(2, (currEditDist - gapCnt) / 4) ;
+#endif
+
+    ++partialCnt ;
+  }
+  
+  int scoreToleranceForMin = EDVec::PERIOD()-1 ;
+  int scoreToleranceForMax = EDVec::PERIOD()/2 ;
+
+#ifdef SW_FEEDBACK
+    int lastValidBand = 0 ;
+    int lastValidScore = initScore ;
+#endif
+
+  alignedQLenLow = queryLen+1 ;
+  alignedQLenHigh = 0 ;
+  alignedRLenLow = 0 ;
+  alignedRLenHigh = 0 ;
+  for (int ai=0; ai < partialCnt; ++ai) {
+
+#ifdef DEBUG0
+    cerr << partials[ai] << endl ;
+#endif
+  
+    int currToleranceForMin = scoreToleranceForMin ;
+    int currToleranceForMax = scoreToleranceForMax ;
+
+#ifdef FINE_ALIGN
+    if (ai != 1 && partials[ai].partialQLen < FINE_ALIGN_CNT && partials[ai].scoreHigh < initScore)
+      currToleranceForMax = 0 ;
+#endif // #ifdef FINE_ALIGN
+    
+#ifdef SW_FEEDBACK
+    if (partials[ai].estimatedBand >= lastValidBand + 8 && 
+	partials[ai].scoreHigh <= lastValidScore) {
+
+      continue ;
+    }
+    lastValidBand = partials[ai].estimatedBand ;
+    lastValidScore = partials[ai].scoreHigh ;
+#endif
+
+    if ((partials[ai].scoreLow >= maxScoreLow - currToleranceForMin) ||
+       	(partials[ai].scoreHigh >= maxScoreHigh - currToleranceForMin)) {
+
+      if (partials[ai].partialQLen < alignedQLenLow) {
+
+	alignedQLenLow = partials[ai].partialQLen ;
+	alignedRLenLow = partials[ai].partialRLen ;
+	
+#ifdef SW_FEEDBACK
+	swfb.updateMin(alignedQLenLow, alignedRLenLow, 
+		       (partials[ai].scoreLow + partials[ai].scoreHigh)/2) ;
+#endif
+      }
+    }
+
+    if ((partials[ai].scoreLow >= maxScoreLow - currToleranceForMax) ||
+	(partials[ai].scoreHigh >= maxScoreHigh - currToleranceForMax)) {
+
+      if (partials[ai].partialQLen > alignedQLenHigh) {
+	alignedQLenHigh = partials[ai].partialQLen ;
+	alignedRLenHigh = partials[ai].partialRLen ;
+#ifdef SW_FEEDBACK
+	swfb.updateMax(alignedQLenHigh, alignedRLenHigh, partials[ai].estimatedBand) ;
+#endif      
+      }
+    }
+  }
+
+  
+#ifdef SW_FEEDBACK
+  // Do adjustments on the feedback values
+  if (swfb.maxQLen > 0)
+    swfb.maxQLen = min(queryLen, swfb.maxQLen + EDVec::PERIOD()-1) ;
+
+  swfb.maxRLen = max(swfb.maxRLen, min(refLen, swfb.maxQLen + swfb.maxBand)) ;
+
+  if (swfb.maxQLen < swfb.minQLen)
+    std::swap(swfb.maxQLen, swfb.minQLen) ;
+  
+  if (swfb.maxRLen < swfb.minRLen)
+    std::swap(swfb.maxRLen, swfb.minRLen) ;
+
+
+  if (abs(swfb.minQLen-swfb.minRLen) > 8) { 
+    // We don't have high confidence for the long gaps. To be conservative, start ksw_extend from 
+    // the beginning, i.e. set the min query and ref indices to 0:
+    swfb.updateMin(0, 0, initScore) ;
+  }
+
+#endif
+
+  assert(alignedQLenLow <= queryLen) ;
+  assert(alignedQLenHigh >= 0) ;
+
+#ifdef DEBUG0
+  cerr << "Max scores computed: [" << maxScoreLow << ", " << maxScoreHigh << "]" << endl ;
+  cerr << "Query alignment range: [" << alignedQLenLow << ", " << alignedQLenHigh << "]" << endl ;
+  cerr << "Ref alignment range: [" << alignedRLenLow << ", " << alignedRLenHigh << "]" << endl ;
+#ifdef SW_FEEDBACK
+  cerr << "The feedback computed: " << swfb << endl ;
+#endif // #ifdef SW_FEEDBACK
+#endif // #ifdef DEBUG0
+
+
+  // Adjust the alignedRLen value for full alignment for obvious cases
+  if (alignedQLenHigh == alignedQLenLow && alignedQLenHigh == queryLen && 
+      alignedRLenHigh == alignedRLenLow && alignedQLenHigh >= 4 && alignedRLenHigh >= 5) {
+
+    int origMatchCnt = 
+      (refSeq[alignedRLenHigh-1] == querySeq[alignedQLenHigh-1])
+      + (refSeq[alignedRLenHigh-2] == querySeq[alignedQLenHigh-2])
+      + (refSeq[alignedRLenHigh-3] == querySeq[alignedQLenHigh-3])
+      + (refSeq[alignedRLenHigh-4] == querySeq[alignedQLenHigh-4]) ;
+
+    int back1MatchCnt =
+      (refSeq[alignedRLenHigh-2] == querySeq[alignedQLenHigh-1])
+      + (refSeq[alignedRLenHigh-3] == querySeq[alignedQLenHigh-2])
+      + (refSeq[alignedRLenHigh-4] == querySeq[alignedQLenHigh-3]) 
+      + (refSeq[alignedRLenHigh-5] == querySeq[alignedQLenHigh-4]) ;
+    
+    int forw1MatchCnt = 0 ;
+    if (alignedRLenHigh < refLen-1) {
+      forw1MatchCnt = 
+	(refSeq[alignedRLenHigh] == querySeq[alignedQLenHigh-1])
+	+ (refSeq[alignedRLenHigh-1] == querySeq[alignedQLenHigh-2])
+	+ (refSeq[alignedRLenHigh-2] == querySeq[alignedQLenHigh-3])
+	+ (refSeq[alignedRLenHigh-3] == querySeq[alignedQLenHigh-4]) ;
+    }
+
+    if (back1MatchCnt > origMatchCnt && back1MatchCnt >= forw1MatchCnt) {
+      --alignedRLenHigh ;
+      --alignedRLenLow ;
+    }
+    else if (forw1MatchCnt > origMatchCnt) {
+      ++alignedRLenHigh ;
+      ++alignedRLenLow ;
+    }
+    
+#ifdef DEBUG0
+    cerr << "Orig/Back-by-1/Forward-by-1 match counts: " << origMatchCnt << " "
+	 << back1MatchCnt << " " << forw1MatchCnt << endl ;
+    cerr << "The aligned ref len is now: " << alignedRLenHigh << endl ;
+#endif
+
+  }
+
+  // In BWA, endBonus is considered during comparisons, but it is not included in the final
+  // score value returned. To be consistent with BWA, we do the following:
+  if (alignedQLenHigh == queryLen)
+    maxScoreHigh -= endBonus ;
+  if (alignedQLenLow == queryLen)
+    maxScoreLow -= endBonus ;
+
+#ifdef DEBUG0
+  cerr << "Init score = " << initScore << endl ;
+  cerr << "Max score-high = " << maxScoreHigh << " for alignedQLen = " 
+       << alignedQLenHigh << ", alignedRLen = " << alignedRLenHigh << endl ;
+  cerr << "Max score-low = " << maxScoreLow << " for alignedQLen = " 
+       << alignedQLenLow << ", alignedRLen = " << alignedRLenLow << endl ;
+#endif
+
+}
+
+
+
+
+void fast_extend_u32(const uint8_t* refSeq, int refLen, const uint8_t* querySeq, int queryLen, 
+		     int initScore, int endBonus, 
+		     int& alignedQLenLow, int& alignedQLenHigh, 
+		     int& alignedRLenLow, int& alignedRLenHigh, 
+		     int& scoreLow, int& scoreHigh, SWFeedback& swFeedback,
+		     int mismatchWt=4, int gapWt=1, int gapOpenWt=6, int ambigWt = 1) {
+  
+  fast_extend<BitVec64, EDVec32Every4>(refSeq, refLen, querySeq, queryLen, 
+				       initScore, endBonus, 
+				       alignedQLenLow, alignedQLenHigh, 
+				       alignedRLenLow, alignedRLenHigh, 
+				       scoreLow, scoreHigh, swFeedback,
+				       mismatchWt, gapWt, gapOpenWt, ambigWt) ;
+}
+
+void fast_extend_u64(const uint8_t* refSeq, int refLen, const uint8_t* querySeq, int queryLen, 
+		     int initScore, int endBonus, 
+		     int& alignedQLenLow, int& alignedQLenHigh, 
+		     int& alignedRLenLow, int& alignedRLenHigh, 
+		     int& scoreLow, int& scoreHigh, SWFeedback& swFeedback,
+		     int mismatchWt=4, int gapWt=1, int gapOpenWt=6, int ambigWt = 1) {
+  
+  fast_extend<BitVec64, EDVec64Every8>(refSeq, refLen, querySeq, queryLen, 
+				       initScore, endBonus, 
+				       alignedQLenLow, alignedQLenHigh, 
+				       alignedRLenLow, alignedRLenHigh, 
+				       scoreLow, scoreHigh, swFeedback,
+				       mismatchWt, gapWt, gapOpenWt, ambigWt) ;
+}
+
+void fast_extend_u64x2(const uint8_t* refSeq, int refLen, const uint8_t* querySeq, int queryLen, 
+		       int initScore, int endBonus, 
+		       int& alignedQLenLow, int& alignedQLenHigh, 
+		       int& alignedRLenLow, int& alignedRLenHigh, 
+		       int& scoreLow, int& scoreHigh, SWFeedback& swFeedback,
+		       int mismatchWt=4, int gapWt=1, int gapOpenWt=6, int ambigWt = 1) {
+
+  fast_extend<BitVec64x2, EDVec128Every16>(refSeq, refLen, querySeq, queryLen, 
+					   initScore, endBonus, 
+					   alignedQLenLow, alignedQLenHigh, 
+					   alignedRLenLow, alignedRLenHigh, 
+					   scoreLow, scoreHigh, swFeedback,
+					   mismatchWt, gapWt, gapOpenWt, ambigWt) ;
+}
+
+void fast_extend_u128(const uint8_t* refSeq, int refLen, const uint8_t* querySeq, int queryLen, 
+		      int initScore, int endBonus, 
+		      int& alignedQLenLow, int& alignedQLenHigh, 
+		      int& alignedRLenLow, int& alignedRLenHigh, 
+		      int& scoreLow, int& scoreHigh, SWFeedback& swFeedback,
+		      int mismatchWt=4, int gapWt=1, int gapOpenWt=6, int ambigWt = 1) {
+
+  fast_extend<BitVec128, EDVec128Every16>(refSeq, refLen, querySeq, queryLen, 
+					  initScore, endBonus, 
+					  alignedQLenLow, alignedQLenHigh, 
+					  alignedRLenLow, alignedRLenHigh, 
+					  scoreLow, scoreHigh, swFeedback,
+					  mismatchWt, gapWt, gapOpenWt, ambigWt) ;
+}
+
+void fast_extend_u256(const uint8_t* refSeq, int refLen, const uint8_t* querySeq, int queryLen, 
+		      int initScore, int endBonus, 
+		      int& alignedQLenLow, int& alignedQLenHigh, 
+		      int& alignedRLenLow, int& alignedRLenHigh, 
+		      int& scoreLow, int& scoreHigh, SWFeedback& swFeedback,
+		      int mismatchWt=4, int gapWt=1, int gapOpenWt=6, int ambigWt = 1) {
+
+#ifdef USE_AVX2
+    if (useavx2) {
+	fast_extend<BitVec256, EDVec256Every16> 
+    (refSeq, refLen, querySeq, queryLen, initScore, endBonus, alignedQLenLow, 
+     alignedQLenHigh, alignedRLenLow, alignedRLenHigh, scoreLow, scoreHigh, swFeedback,
+     mismatchWt, gapWt, gapOpenWt, ambigWt) ;
+    } else {
+#endif
+    fast_extend<BitVec128x2, EDVec128x2Every16>
+    (refSeq, refLen, querySeq, queryLen, initScore, endBonus, alignedQLenLow, 
+     alignedQLenHigh, alignedRLenLow, alignedRLenHigh, scoreLow, scoreHigh, swFeedback,
+     mismatchWt, gapWt, gapOpenWt, ambigWt) ;
+#ifdef USE_AVX2
+	}
+#endif
+
+}
+
+
+void fast_extend(const uint8_t* refSeq, int refLen, const uint8_t* querySeq, int queryLen,
+		 int initScore, int endBonus, 
+		 int& alignedQLenLow, int& alignedQLenHigh, 
+		 int& alignedRLenLow, int& alignedRLenHigh, 
+		 int& scoreLow, int& scoreHigh, SWFeedback& swFeedback,
+		 int mismatchWt=4, int gapWt=1, int gapOpenWt=6, int ambigWt = 1) {
+  
+  if (queryLen < 15) {
+    cerr << "Warning: It is not recommended to use SW filtering API for queries shorter than 15 bases!" << endl ;
+  }
+
+  if (queryLen <= 32)
+    fast_extend_u32(refSeq, refLen, querySeq, queryLen, initScore, endBonus,
+		    alignedQLenLow, alignedQLenHigh, alignedRLenLow, alignedRLenHigh,
+		    scoreLow, scoreHigh, swFeedback, mismatchWt, gapWt, gapOpenWt, ambigWt) ;
+
+  else if (queryLen <= 63)
+    fast_extend_u64(refSeq, refLen, querySeq, queryLen, initScore, endBonus,
+		    alignedQLenLow, alignedQLenHigh, alignedRLenLow, alignedRLenHigh,
+		    scoreLow, scoreHigh, swFeedback, mismatchWt, gapWt, gapOpenWt, ambigWt) ;
+
+
+  else if (queryLen <= 127)
+    fast_extend_u128(refSeq, refLen, querySeq, queryLen, initScore, endBonus,
+		     alignedQLenLow, alignedQLenHigh, alignedRLenLow, alignedRLenHigh,
+		     scoreLow, scoreHigh, swFeedback, mismatchWt, gapWt, gapOpenWt, ambigWt) ;
+
+  else if (queryLen <= 255)
+    fast_extend_u256(refSeq, refLen, querySeq, queryLen, initScore, endBonus,
+		     alignedQLenLow, alignedQLenHigh, alignedRLenLow, alignedRLenHigh,
+		     scoreLow, scoreHigh, swFeedback, mismatchWt, gapWt, gapOpenWt, ambigWt) ;
+
+  else {
+    // The return values indicate an ambigious match
+    alignedQLenLow = alignedRLenLow = 0 ;
+    alignedQLenHigh = queryLen ;
+    alignedRLenHigh = refLen ;
+    scoreLow = 0 ;
+    scoreHigh = queryLen ;
+    cerr << "Warning: Skipping edit distance computation because reads longer than 126 bases not supported yet" << endl ;
+  }
+}
+
+
+void fast_filter(const uint8_t* refSeq, int refLen, const uint8_t* querySeq, int queryLen,
+		 int initScore, int endBonus, 
+		 int& alignedQLen, int& alignedRLen, int& score, float& confidence,
+		 int mismatchWt, int gapWt, int gapOpenWt, int ambigWt) {
+  
+  int alignedQLenLow, alignedQLenHigh, alignedRLenLow, alignedRLenHigh, scoreLow, scoreHigh ;
+  SWFeedback swFeedback ;
+
+  fast_extend(refSeq, refLen, querySeq, queryLen, initScore, endBonus,
+	      alignedQLenLow, alignedQLenHigh, alignedRLenLow, alignedRLenHigh,
+	      scoreLow, scoreHigh, swFeedback, 
+	      mismatchWt, gapWt, gapOpenWt, ambigWt) ;
+  
+  alignedQLen = (alignedQLenLow + alignedQLenHigh)/2 ;
+  alignedRLen = (alignedRLenLow + alignedRLenHigh)/2 ;
+  score = (scoreLow + scoreHigh)/2 ;
+  confidence = 
+    (alignedQLenLow == alignedQLenHigh && alignedRLenLow == alignedRLenHigh) ? 1.0 : 0.0 ;
+
+}
+
+void fast_filter_and_extend(const uint8_t* refSeq, int refLen, const uint8_t* querySeq, int queryLen,
+			    int initScore, int endBonus, int zdrop,
+			    int& alignedQLen, int& alignedRLen, int& score,
+			    int costMatrixRowCnt, const int8_t* costMatrix, 
+			    int gapWt, int gapOpenWt) {
+
+  int mismatchWt = -1 * costMatrix[1] ;
+  int ambigWt = -1 * costMatrix[costMatrixRowCnt*costMatrixRowCnt-1] ;
+
+  int alignedQLenLow, alignedQLenHigh, alignedRLenLow, alignedRLenHigh, scoreLow, scoreHigh ;
+  SWFeedback swFeedback ;
+
+  fast_extend(refSeq, refLen, querySeq, queryLen, initScore, endBonus,
+	      alignedQLenLow, alignedQLenHigh, alignedRLenLow, alignedRLenHigh,
+	      scoreLow, scoreHigh, swFeedback,
+	      mismatchWt, gapWt, gapOpenWt, ambigWt) ;
+  
+  score = (scoreLow + scoreHigh) / 2 ;
+  alignedQLen = (alignedQLenLow + alignedQLenHigh)/2 ;
+  alignedRLen = (alignedRLenLow + alignedRLenHigh)/2 ;  
+
+  bool partialQ = (alignedQLenLow != alignedQLenHigh) || 
+    (alignedQLenLow > 0 && alignedQLenLow < queryLen && alignedRLenLow < refLen) ;
+  bool partialR = (alignedRLenLow != alignedRLenHigh) ;
+
+  if (partialQ || partialR) {
+
+#ifdef DEBUG0
+    cerr << "Partial alignment: Running ksw_extend with feedback: " << swFeedback << endl ;
+#endif
+
+    if (swFeedback.maxQLen == swFeedback.minQLen) {
+      alignedQLen = swFeedback.minQLen ;
+      alignedRLen = swFeedback.minRLen ;
+      score = swFeedback.minScore ;
+#ifdef DEBUG0
+      cerr << "Skipped ksw_extend because of zero query length" << endl ;
+#endif
+    }
+    else {
+      int endBonusUpdated = (swFeedback.maxQLen == queryLen) ? endBonus : 0 ;
+      score = run_ksw_extend(refSeq+swFeedback.minRLen, swFeedback.maxRLen-swFeedback.minRLen, 
+			     querySeq+swFeedback.minQLen, swFeedback.maxQLen-swFeedback.minQLen,
+			     swFeedback.maxBand, swFeedback.minScore, endBonusUpdated, zdrop, 
+			     costMatrixRowCnt, costMatrix, gapOpenWt, gapWt,
+			     alignedQLen, alignedRLen) ;
+
+      alignedQLen += swFeedback.minQLen ;
+      alignedRLen += swFeedback.minRLen ;
+    }
+    
+#ifdef DEBUG1
+    cerr << "The final alignment: " << alignedQLen << " " << alignedRLen 
+	 << " with score " << score << endl ;
+
+    int alignedQLenOrig=-1, alignedRLenOrig=-1 ;
+    int scoreOrig = run_ksw_extend(refSeq, refLen, querySeq, queryLen, queryLen, initScore, endBonus,
+				   zdrop, costMatrixRowCnt, costMatrix, gapOpenWt, gapWt,
+				   alignedQLenOrig, alignedRLenOrig) ;
+    cerr << "The original alignment was: " << alignedQLenOrig << " " << alignedRLenOrig 
+	 << " with score " << scoreOrig << endl ;
+
+    if (alignedQLenOrig != alignedQLen) 
+      cerr << "Mismatch in query lengths: " << alignedQLen << " vs. " << alignedQLenOrig 
+	   << " with scores " << score << " vs. " << scoreOrig << endl ;
+#endif    
+  }
+#ifdef DEBUG1
+  else {
+    cerr << ((alignedQLenHigh == 0) ? "No alignment" : "Full alignment") << endl ;
+
+    int alignedQLenOrig=-1, alignedRLenOrig=-1 ;
+
+    int scoreOrig = run_ksw_extend(refSeq, refLen, querySeq, queryLen, queryLen, initScore, endBonus,
+				   zdrop, costMatrixRowCnt, costMatrix, gapOpenWt, gapWt,
+				   alignedQLenOrig, alignedRLenOrig) ;
+
+    cerr << "The original alignment was: " << alignedQLenOrig << " " << alignedRLenOrig 
+	 << " with score " << scoreOrig << endl ;
+
+  }
+#endif
+
+  assert(alignedQLen >= 0 && alignedQLen <= queryLen) ;
+  assert(alignedRLen >= 0 && alignedRLen <= refLen) ;
+}
+
+
+
+void init_fast_extend(bool avx2present) {
+#ifdef FINE_ALIGN
+  BitCount8::init_lut() ;
+#endif
+  //Set ksw_extend functions
+#ifdef USE_AVX2
+  if (avx2present) {
+      useavx2 = avx2present;
+      ksw_extend_16 = ksw_extend_avx2_16;
+      ksw_extend_32 = ksw_extend_avx2_32;
+  } else {
+#endif
+      ksw_extend_16 = ksw_extend_sse_16;
+      ksw_extend_32 = ksw_extend;
+#ifdef USE_AVX2
+  }
+#endif
+}
+
+
+uint8_t BitCount8::lut_[] ;
+void BitCount8::init_lut() {
+
+  for (int bitV=0; bitV < 256; ++bitV) {
+
+    // The following is from Brian Kernighan
+    // See: "Bit Twiddling Hacks"
+    int cnt ;
+    int val = bitV ;
+    for (cnt=0; val ; ++cnt) {
+      val &= val - 1 ; // clear the least significant bit set
+    }
+    lut_[bitV] = cnt ;
+  }
+
+}
+

--- a/intel_opt/fast_extend_fine.h
+++ b/intel_opt/fast_extend_fine.h
@@ -1,0 +1,91 @@
+/* 
+The MIT License (MIT)
+Copyright (c) 2014 Intel Corp.
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include <stdint.h>
+#include <iostream>
+
+// Alternatively, can use popcnt instruction
+class BitCount8 {
+  static uint8_t lut_[256] ;
+
+ public:
+
+  static void init_lut() ;
+  
+  static int getCnt(uint8_t bitVec) {
+    return lut_[bitVec] ;
+  }
+
+} ;
+
+// Alternatively, can use popcnt instruction
+class BitCount16 {
+  static uint8_t lut_[256] ;
+
+ public:
+
+  static void init_lut() ;
+  
+  static int getCnt(uint16_t bitVec) {
+    return BitCount8::getCnt((uint8_t) (bitVec >> 8)) + 
+      BitCount8::getCnt((uint8_t) bitVec) ;
+  }
+  
+} ;
+
+
+// Fine-grain alignment for up to the first 16 bases.
+// Note that this returns the correct edit distance at cells (i,j) for i=j
+class FineAlignment16 {
+
+  int queryLen_, endBonus_ ;
+  
+  int bestAlignedLen_ ;
+  int maxScore_ ;
+
+  int mismatchWtP1_ ; // mismatch weight plus one
+  int ambigWtP1_ ; // ambig weight plus one
+  
+
+ public:
+
+ FineAlignment16(int queryLen, int endBonus, int mismatchWt, int ambigWt)
+   : queryLen_(queryLen), endBonus_(endBonus), bestAlignedLen_(0), maxScore_(0),
+    mismatchWtP1_(mismatchWt+1), ambigWtP1_(ambigWt+1) {}
+  
+  void update(uint16_t UP0, uint16_t UP1, int partialLen, int ambigCnt) {
+    uint16_t mask = ((uint32_t)(1) << partialLen) - 1 ; // clear higher bits beyond partialLen
+    UP0 &= mask ;
+    UP1 &= mask ;
+    
+    int editDist = partialLen + 
+      ((partialLen <= 8) ? 
+       (BitCount8::getCnt((uint8_t)UP0) - BitCount8::getCnt((uint8_t)UP1)) :
+       (BitCount16::getCnt(UP0) - BitCount16::getCnt(UP1))) ;
+    
+    int bonus = (partialLen == queryLen_) ? endBonus_ : 0 ;
+    
+    int score = partialLen - editDist * mismatchWtP1_ - ambigCnt * ambigWtP1_ + bonus ;
+
+    if (score > maxScore_) {
+      maxScore_ = score ;
+      bestAlignedLen_ = partialLen ;
+    }
+  }
+  
+  void getBest(int& alignedLen, int& score) {
+    alignedLen = bestAlignedLen_ ;
+    score = maxScore_ ;
+  }
+
+  friend std::ostream& operator<< (std::ostream& os, const FineAlignment16& a) {
+    os << "{maxScore = " << a.maxScore_ << ", best col: " << a.bestAlignedLen_ << "}" << endl ;
+    return os ;
+  }
+
+} ;

--- a/intel_opt/fast_extend_vec.h
+++ b/intel_opt/fast_extend_vec.h
@@ -1,0 +1,50 @@
+/* 
+The MIT License (MIT)
+Copyright (c) 2014 Intel Corp.
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef _FAST_EXTEND_VEC_H
+#define _FAST_EXTEND_VEC_H
+
+#include <immintrin.h>
+#include <xmmintrin.h>
+#include <emmintrin.h>
+
+#ifdef USE_SSE4
+#include <tmmintrin.h>
+#include <smmintrin.h>
+
+#define BLENDV(__v1, __v2, __pred)		\
+  _mm_blendv_epi8(__v1, __v2, __pred)
+
+#else // #ifdef USE_SSE4
+
+#define BLENDV(__v1, __v2, __pred)					\
+  _mm_or_si128(_mm_andnot_si128(__pred, __v1), _mm_and_si128(__v2, __pred))
+
+#endif // #ifdef USE_SSE4
+
+using std::cout ;
+using std::endl ;
+
+inline void printVec16(const __m128i& v) {
+  
+  cout << "{" ;
+  cout << " " << _mm_extract_epi16(v, 0) ;
+  cout << " " << _mm_extract_epi16(v, 1) ;
+  cout << " " << _mm_extract_epi16(v, 2) ;
+  cout << " " << _mm_extract_epi16(v, 3) ;
+  cout << " " <<_mm_extract_epi16(v, 4) ;
+  cout << " " <<_mm_extract_epi16(v, 5) ;
+  cout << " " <<_mm_extract_epi16(v, 6) ;
+  cout << " " <<_mm_extract_epi16(v, 7) ;
+
+  cout << "}" << endl ;
+}
+
+
+
+#endif // #ifdef _FAST_EXTEND_VEC_H

--- a/intel_opt/fast_extend_vec128.h
+++ b/intel_opt/fast_extend_vec128.h
@@ -1,0 +1,243 @@
+/* 
+The MIT License (MIT)
+Copyright (c) 2014 Intel Corp.
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef _FAST_EXTEND_VEC128_H
+#define _FAST_EXTEND_VEC128_H
+
+#include "fast_extend_vec.h"
+#include "fast_extend_bitv64.h"
+#include "fast_extend_bitv64x2.h"
+#include "fast_extend_bitv128.h"
+
+//
+// Edit distance vector for a 128-bit query.
+// The probes are at every 16 bases. Each probe is 16 bits.
+// There are 8 probes in total.
+//
+class EDVec128Every16 {
+  __m128i vec_ ;
+  static const int WORD_CNT_ = 8 ;
+  static const int PERIOD_ = 16 ;
+
+  // Update equality operator if more members are added
+
+ public:
+  EDVec128Every16() {}
+
+  explicit EDVec128Every16(__m128i v):vec_(v) {}
+  explicit EDVec128Every16(int16_t val):vec_(_mm_set1_epi16(val)) {}
+  explicit EDVec128Every16(const BitVec64& bv): vec_(_mm_set_epi64x(0, bv.bitV)) {}
+  explicit EDVec128Every16(const BitVec64x2& bv): vec_(_mm_set_epi64x(bv.bitV[1], bv.bitV[0])) {}
+  explicit EDVec128Every16(const BitVec128& bv): vec_(bv.bitV) {}
+
+
+  inline void setAll(int16_t val) {
+    vec_ = _mm_set1_epi16(val) ;    
+  }
+
+  static int16_t getMaxWordVal() { return std::numeric_limits<int16_t>::max() ;}
+
+  inline int getWord(int index) const {
+    switch(index) {
+    case 0: return _mm_extract_epi16(vec_, 0) ;
+    case 1: return  _mm_extract_epi16(vec_, 1) ;
+    case 2: return  _mm_extract_epi16(vec_, 2) ;
+    case 3: return  _mm_extract_epi16(vec_, 3) ;
+    case 4: return  _mm_extract_epi16(vec_, 4) ;
+    case 5: return  _mm_extract_epi16(vec_, 5) ;
+    case 6: return  _mm_extract_epi16(vec_, 6) ;
+    case 7: return  _mm_extract_epi16(vec_, 7) ;
+    default: assert(false); return 0 ;
+    }
+  }
+
+  bool allLessThanOrEqualTo(const EDVec128Every16& other) const {
+    // Each elt in pred will be set to 0xFFFF if the element in this vector 
+    // is greater than the corresponding element in other
+    __m128i pred = _mm_cmpgt_epi16(vec_, other.vec_) ; 
+    int flags = _mm_movemask_epi8(pred) ; // creates a mask from MSB of each 8-bit elt in pred
+
+    return flags == 0 ; // if there's at least one elt greater than "other", flags != 0
+  }
+
+  inline void setWords (int* v) {
+    vec_ = _mm_set_epi16(v[7], v[6], v[5], v[4], v[3], v[2], v[1], v[0]) ;
+  }
+
+  inline void setFirstWord(int val) {
+    vec_ = _mm_insert_epi16(vec_, val, 0) ;
+  }
+
+  inline void setAllWords (uint16_t val) {
+    vec_ = _mm_set1_epi16(val) ;
+  }
+
+  inline void setWordsAsMask () {
+    vec_ = _mm_set1_epi16(0x1) ;
+  }
+
+  static int getLastWordIndexFor (int queryLen) {
+    int baseIndex = queryLen - 1 ;
+    return baseIndex/PERIOD_ ;
+  }
+
+  static int getProbeOffsetFor (int queryLen) {
+    return (queryLen-1) % PERIOD_ ;
+  }
+
+  void setWordsAsEndBonus(int queryLen, int endBonus) {
+    int v[WORD_CNT_] = {0, 0, 0, 0, 0, 0, 0, 0} ;
+    
+    int lastWordIndex = getLastWordIndexFor(queryLen) ;    
+    v[lastWordIndex] = endBonus ;
+
+    setWords(v) ;
+  }
+
+  void setWordsAsBadScore(int queryLen, int thr, int infScore) {
+    int v[WORD_CNT_] = {thr, thr, thr, thr, thr, thr, thr, thr} ;
+    
+    int lastWordIndex = getLastWordIndexFor(queryLen) ;    
+    for (int i=lastWordIndex+1; i < WORD_CNT_; ++i) {
+      v[i] = infScore ;
+    }
+    setWords(v) ;
+  }
+
+  static int getDistAt(int wordIndex, int queryLen) {
+    return 1+ wordIndex * PERIOD_ + getProbeOffsetFor(queryLen) ;
+  }
+
+  void setWordsAsDist (int queryLen, int distWt) {
+    int v[WORD_CNT_] ;
+    int bitOffset = getProbeOffsetFor(queryLen) ;
+
+    for (int wi=0; wi < WORD_CNT_; ++wi) {
+      v[wi] = distWt * (1 + wi * PERIOD_ + bitOffset) ;
+    }
+    setWords(v) ;
+  }
+
+  void setMin(const EDVec128Every16& other) {
+    vec_ = _mm_min_epi16(vec_, other.vec_) ;
+  }
+
+  void setMin(const EDVec128Every16& other, EDVec128Every16& bestIndices, const EDVec128Every16& otherIndices) {
+    __m128i pred = _mm_cmplt_epi16(other.vec_, vec_) ; // pred is 0xFFFF if other < this
+    vec_ = BLENDV(vec_, other.vec_, pred) ; // if pred is 0, choose this; o/w choose other
+    bestIndices.vec_ = BLENDV(bestIndices.vec_, otherIndices.vec_, pred) ;
+  }
+
+  void setMax(const EDVec128Every16& other, EDVec128Every16& bestIndices, const EDVec128Every16& otherIndices) {
+    __m128i pred = _mm_cmpgt_epi16(other.vec_, vec_) ; // pred is 0xFFFF if other > this
+    vec_ = BLENDV(vec_, other.vec_, pred) ; // if pred is 0, choose this; o/w choose other
+    bestIndices.vec_ = BLENDV(bestIndices.vec_, otherIndices.vec_, pred) ;
+  }
+
+  void setMax(const EDVec128Every16& other, EDVec128Every16& bestIndices, const EDVec128Every16& otherIndices, EDVec128Every16& bestAccumDist, const EDVec128Every16& otherAccumDist) {
+    __m128i pred = _mm_cmpgt_epi16(other.vec_, vec_) ; // pred is 0xFFFF if other > this
+    vec_ = BLENDV(vec_, other.vec_, pred) ; // if pred is 0, choose this; o/w choose other
+    bestIndices.vec_ = BLENDV(bestIndices.vec_, otherIndices.vec_, pred) ;
+    bestAccumDist.vec_ = BLENDV(bestAccumDist.vec_, otherAccumDist.vec_, pred) ;
+  }
+
+  // The return value will be nonzero iff at least one of the entries is updated
+  // 2 bits per word is returned because of SSE limitations.
+  uint32_t setMaxAndReturnFlag(const EDVec128Every16& other, EDVec128Every16& bestIndices, const EDVec128Every16& otherIndices) {
+    __m128i pred = _mm_cmpgt_epi16(other.vec_, vec_) ; // pred is 0xFFFF if other > this
+    vec_ = BLENDV(vec_, other.vec_, pred) ; // if pred is 0, choose this; o/w choose other
+    bestIndices.vec_ = BLENDV(bestIndices.vec_, otherIndices.vec_, pred) ;
+    
+    return (uint32_t) _mm_movemask_epi8(pred) ;
+  }
+
+  // The return value will be nonzero iff at least one of the entries is updated
+  // 2 bits per word is returned because of SSE limitations.
+  uint32_t setMaxAndReturnFlag(const EDVec128Every16& other, EDVec128Every16& bestIndices, const EDVec128Every16& otherIndices, EDVec128Every16& bestAccumDist, const EDVec128Every16& otherAccumDist) {
+    __m128i pred = _mm_cmpgt_epi16(other.vec_, vec_) ; // pred is 0xFFFF if other > this
+    vec_ = BLENDV(vec_, other.vec_, pred) ; // if pred is 0, choose this; o/w choose other
+    bestIndices.vec_ = BLENDV(bestIndices.vec_, otherIndices.vec_, pred) ;
+    bestAccumDist.vec_ = BLENDV(bestAccumDist.vec_, otherAccumDist.vec_, pred) ;
+    
+    return (uint32_t) _mm_movemask_epi8(pred) ;
+  }
+
+  void addThirdIfFirstGTSecond(const EDVec128Every16& first, const EDVec128Every16& second, 
+			       const EDVec128Every16& third, const EDVec128Every16& zero) {
+
+    __m128i pred = _mm_cmpgt_epi16(first.vec_, second.vec_) ; 
+    // pred is 0xFFFF if first > second
+
+    // If pred is 0, then blendv will add zero; o/w it will add third
+    vec_ = _mm_add_epi16(vec_, BLENDV(zero.vec_, third.vec_, pred)) ;
+  }
+ 
+  EDVec128Every16 subSat(const EDVec128Every16& other) const {
+    return EDVec128Every16(_mm_subs_epu16(this->vec_, other.vec_)) ;
+  }
+
+  inline EDVec128Every16 shiftBitsRightWithinWords(int shiftVal) {
+    return EDVec128Every16(_mm_srli_epi16(vec_, shiftVal)) ;
+  }
+
+  inline void shiftWordsLeftByOne() {
+    vec_ = _mm_slli_si128(vec_, 2) ; // 16-bit shift = 2 * 8-bit shift
+  }
+
+  inline bool operator == (const EDVec128Every16& other) {
+    return _mm_movemask_epi8(_mm_cmpeq_epi16(vec_, other.vec_)) == 0xFFFF ;
+  }
+
+  inline EDVec128Every16& operator += (const EDVec128Every16& other) {
+    vec_ = _mm_add_epi16(vec_, other.vec_) ;
+    return *this ;
+  }
+
+  inline EDVec128Every16& operator -= (const EDVec128Every16& other) {
+    vec_ = _mm_sub_epi16(vec_, other.vec_) ;
+    return *this ;
+  }
+
+  inline EDVec128Every16 operator+ (const EDVec128Every16& other) const {
+    return EDVec128Every16(_mm_add_epi16(vec_, other.vec_)) ;
+  }
+
+  inline EDVec128Every16 operator- (const EDVec128Every16& other) const {
+    return EDVec128Every16(_mm_sub_epi16(vec_, other.vec_)) ;
+  }
+
+  inline EDVec128Every16 operator* (const EDVec128Every16& other) const {
+    return EDVec128Every16(_mm_mullo_epi16(vec_, other.vec_)) ;
+  }
+
+  inline EDVec128Every16 operator& (const EDVec128Every16& other) const {
+    return EDVec128Every16(_mm_and_si128(vec_, other.vec_)) ;
+  }
+
+  static int WORD_CNT() {
+    return WORD_CNT_ ;
+  }
+
+  static int PERIOD() {
+    return PERIOD_ ;
+  }
+
+  friend std::ostream& operator<< (std::ostream& os, const EDVec128Every16& v) {
+    os << "{" ;
+    for (int i=0; i < WORD_CNT_; ++i) {
+      os << v.getWord(i) << " " ;
+    }
+    os << "}" ;
+    return os ;
+  }
+
+} ;
+
+
+
+#endif // #ifndef _FAST_EXTEND_VEC128_H

--- a/intel_opt/fast_extend_vec128x2.h
+++ b/intel_opt/fast_extend_vec128x2.h
@@ -1,0 +1,314 @@
+/* 
+The MIT License (MIT)
+Copyright (c) 2014 Intel Corp.
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef _FAST_EXTEND_VEC128x2_H
+#define _FAST_EXTEND_VEC128x2_H
+
+#include <limits>
+
+#include "fast_extend_vec.h"
+#include "fast_extend_bitv128.h"
+#include "fast_extend_bitv128x2.h"
+
+#ifdef USE_AVX2
+#include "fast_extend_bitv256.h"
+#endif
+
+//
+// Edit distance vector for a less-than-255-base query.
+// The probes are at every 16 bases. Each probe is 16 bits.
+// There are 16 probes in total.
+//
+class EDVec128x2Every16 {
+  __m128i vec_[2] ;
+  static const int WORD_CNT_ = 16 ;
+  static const int PERIOD_ = 16 ;
+
+ public:
+  EDVec128x2Every16() {}
+
+  explicit EDVec128x2Every16(__m128i v0, __m128i v1) {
+    vec_[0] = v0 ;
+    vec_[1] = v1 ;
+  }
+
+  explicit EDVec128x2Every16(int16_t val) {
+    vec_[0] = _mm_set1_epi16(val) ;
+    vec_[1] = _mm_set1_epi16(val) ; 
+  }
+
+  explicit EDVec128x2Every16(const BitVec128x2& bv) {
+    vec_[0] = bv.bitV[0] ;
+    vec_[1] = bv.bitV[1] ;
+  }
+
+#ifdef USE_AVX2
+  explicit EDVec128x2Every16(const BitVec256& bv) {
+    vec_[0] = _mm256_castsi256_si128(bv.bitV) ;
+    vec_[1] = _mm256_extractf128_si256(bv.bitV, 1) ;
+  }
+#endif
+
+  inline void setAll(int16_t val) {
+    vec_[0] = _mm_set1_epi16(val) ;    
+    vec_[1] = _mm_set1_epi16(val) ;    
+  }
+
+  static int16_t getMaxWordVal() { return std::numeric_limits<int16_t>::max() ;}
+
+  inline int getWord(int index) const {
+    switch(index) {
+    case 0: return _mm_extract_epi16(vec_[0], 0) ;
+    case 1: return  _mm_extract_epi16(vec_[0], 1) ;
+    case 2: return  _mm_extract_epi16(vec_[0], 2) ;
+    case 3: return  _mm_extract_epi16(vec_[0], 3) ;
+    case 4: return  _mm_extract_epi16(vec_[0], 4) ;
+    case 5: return  _mm_extract_epi16(vec_[0], 5) ;
+    case 6: return  _mm_extract_epi16(vec_[0], 6) ;
+    case 7: return  _mm_extract_epi16(vec_[0], 7) ;
+    case 8: return  _mm_extract_epi16(vec_[1], 0) ;
+    case 9: return  _mm_extract_epi16(vec_[1], 1) ;
+    case 10: return  _mm_extract_epi16(vec_[1], 2) ;
+    case 11: return  _mm_extract_epi16(vec_[1], 3) ;
+    case 12: return  _mm_extract_epi16(vec_[1], 4) ;
+    case 13: return  _mm_extract_epi16(vec_[1], 5) ;
+    case 14: return  _mm_extract_epi16(vec_[1], 6) ;
+    case 15: return  _mm_extract_epi16(vec_[1], 7) ;
+    default: assert(false); return 0 ;
+    }
+  }
+
+  bool allLessThanOrEqualTo(const EDVec128x2Every16& other) const {
+    // Each elt in pred will be set to 0xFFFF if the element in this vector 
+    // is greater than the corresponding element in other
+    __m128i pred0 = _mm_cmpgt_epi16(vec_[0], other.vec_[0]) ; 
+    __m128i pred1 = _mm_cmpgt_epi16(vec_[1], other.vec_[1]) ; 
+    int flags0 = _mm_movemask_epi8(pred0) ; // creates a mask from MSB of each 8-bit elt in pred
+    int flags1 = _mm_movemask_epi8(pred1) ; // creates a mask from MSB of each 8-bit elt in pred
+
+    return (flags0 | flags1) == 0 ; 
+    // if there's at least one elt greater than "other", flags != 0
+  }
+
+  inline void setWords (int* v) {
+    vec_[0] = _mm_set_epi16(v[7],  v[6],  v[5],  v[4],  v[3],  v[2],  v[1], v[0]) ;
+    vec_[1] = _mm_set_epi16(v[15], v[14], v[13], v[12], v[11], v[10], v[9], v[8]) ;
+  }
+
+  inline void setFirstWord(int val) {
+    vec_[0] = _mm_insert_epi16(vec_[0], val, 0) ;
+  }
+
+  inline void setAllWords (uint16_t val) {
+    vec_[0] = _mm_set1_epi16(val) ;
+    vec_[1] = _mm_set1_epi16(val) ;
+  }
+
+  inline void setWordsAsMask () {
+    vec_[0] = _mm_set1_epi16(0x1) ;
+    vec_[1] = _mm_set1_epi16(0x1) ;
+  }
+
+  static int getLastWordIndexFor (int queryLen) {
+    int baseIndex = queryLen - 1 ;
+    return baseIndex/PERIOD_ ;
+  }
+
+  static int getProbeOffsetFor (int queryLen) {
+    return (queryLen-1) % PERIOD_ ;
+  }
+
+  void setWordsAsEndBonus(int queryLen, int endBonus) {
+    int v[WORD_CNT_] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0} ;
+    
+    int lastWordIndex = getLastWordIndexFor(queryLen) ;    
+    v[lastWordIndex] = endBonus ;
+
+    setWords(v) ;
+  }
+
+  void setWordsAsBadScore(int queryLen, int thr, int infScore) {
+    int v[WORD_CNT_] = {thr, thr, thr, thr, thr, thr, thr, thr, thr, thr, thr, thr, thr, thr, thr, thr} ;
+    
+    int lastWordIndex = getLastWordIndexFor(queryLen) ;    
+    for (int i=lastWordIndex+1; i < WORD_CNT_; ++i) {
+      v[i] = infScore ;
+    }
+
+    setWords(v) ;
+  }
+
+  static int getDistAt(int wordIndex, int queryLen) {
+    return 1 + wordIndex * PERIOD_ + getProbeOffsetFor(queryLen) ;
+  }
+
+  void setWordsAsDist (int queryLen, int distWt) {
+    int v[WORD_CNT_] ;
+    int bitOffset = getProbeOffsetFor(queryLen) ;
+
+    for (int wi=0; wi < WORD_CNT_; ++wi) {
+      v[wi] = distWt * (1 + wi * PERIOD_ + bitOffset) ;
+    }
+    setWords(v) ;
+  }
+
+  void setMin(const EDVec128x2Every16& other) {
+    vec_[0] = _mm_min_epi16(vec_[0], other.vec_[0]) ;
+    vec_[1] = _mm_min_epi16(vec_[1], other.vec_[1]) ;
+  }
+
+  void setMin(const EDVec128x2Every16& other, EDVec128x2Every16& bestIndices, const EDVec128x2Every16& otherIndices) {
+    __m128i pred0 = _mm_cmplt_epi16(other.vec_[0], vec_[0]) ; // pred is 0xFFFF if other < this
+    __m128i pred1 = _mm_cmplt_epi16(other.vec_[1], vec_[1]) ; // pred is 0xFFFF if other < this
+
+    vec_[0] = BLENDV(vec_[0], other.vec_[0], pred0) ; // if pred is 0, choose this; o/w choose other
+    vec_[1] = BLENDV(vec_[1], other.vec_[1], pred1) ; // if pred is 0, choose this; o/w choose other
+
+    bestIndices.vec_[0] = BLENDV(bestIndices.vec_[0], otherIndices.vec_[0], pred0) ;
+    bestIndices.vec_[1] = BLENDV(bestIndices.vec_[1], otherIndices.vec_[1], pred1) ;
+  }
+
+  void setMax(const EDVec128x2Every16& other, EDVec128x2Every16& bestIndices, const EDVec128x2Every16& otherIndices) {
+    __m128i pred0 = _mm_cmpgt_epi16(other.vec_[0], vec_[0]) ; // pred is 0xFFFF if other > this
+    __m128i pred1 = _mm_cmpgt_epi16(other.vec_[1], vec_[1]) ; // pred is 0xFFFF if other > this
+
+    vec_[0] = BLENDV(vec_[0], other.vec_[0], pred0) ; // if pred is 0, choose this; o/w choose other
+    vec_[1] = BLENDV(vec_[1], other.vec_[1], pred1) ; // if pred is 0, choose this; o/w choose other
+
+    bestIndices.vec_[0] = BLENDV(bestIndices.vec_[0], otherIndices.vec_[0], pred0) ;
+    bestIndices.vec_[1] = BLENDV(bestIndices.vec_[1], otherIndices.vec_[1], pred1) ;
+  }
+
+  void setMax(const EDVec128x2Every16& other, EDVec128x2Every16& bestIndices, const EDVec128x2Every16& otherIndices, EDVec128x2Every16& bestAccumDist, const EDVec128x2Every16& otherAccumDist) {
+ 
+   __m128i pred0 = _mm_cmpgt_epi16(other.vec_[0], vec_[0]) ; // pred is 0xFFFF if other > this
+   __m128i pred1 = _mm_cmpgt_epi16(other.vec_[1], vec_[1]) ; // pred is 0xFFFF if other > this
+
+    vec_[0] = BLENDV(vec_[0], other.vec_[0], pred0) ; // if pred is 0, choose this; o/w choose other
+    vec_[1] = BLENDV(vec_[1], other.vec_[1], pred1) ; // if pred is 0, choose this; o/w choose other
+
+    bestIndices.vec_[0] = BLENDV(bestIndices.vec_[0], otherIndices.vec_[0], pred0) ;
+    bestIndices.vec_[1] = BLENDV(bestIndices.vec_[1], otherIndices.vec_[1], pred1) ;
+
+    bestAccumDist.vec_[0] = BLENDV(bestAccumDist.vec_[0], otherAccumDist.vec_[0], pred0) ;
+    bestAccumDist.vec_[1] = BLENDV(bestAccumDist.vec_[1], otherAccumDist.vec_[1], pred1) ;
+  }
+
+  // The return value will be nonzero iff at least one of the entries is updated.
+  // 2 bits per word is returned because of SSE limitations.
+  uint32_t setMaxAndReturnFlag(const EDVec128x2Every16& other, EDVec128x2Every16& bestIndices, const EDVec128x2Every16& otherIndices) {
+    __m128i pred0 = _mm_cmpgt_epi16(other.vec_[0], vec_[0]) ; // pred is 0xFFFF if other > this
+    __m128i pred1 = _mm_cmpgt_epi16(other.vec_[1], vec_[1]) ; // pred is 0xFFFF if other > this
+    
+    vec_[0] = BLENDV(vec_[0], other.vec_[0], pred0) ; // if pred is 0, choose this; o/w choose other
+    vec_[1] = BLENDV(vec_[1], other.vec_[1], pred1) ; // if pred is 0, choose this; o/w choose other
+    
+    bestIndices.vec_[0] = BLENDV(bestIndices.vec_[0], otherIndices.vec_[0], pred0) ;
+    bestIndices.vec_[1] = BLENDV(bestIndices.vec_[1], otherIndices.vec_[1], pred1) ;
+    
+    return (((uint32_t) _mm_movemask_epi8(pred1)) << 16) | _mm_movemask_epi8(pred0) ;
+  }
+  
+  // The return value will be nonzero iff at least one of the entries is updated.
+  // 2 bits per word is returned because of SSE limitations.
+  uint32_t setMaxAndReturnFlag(const EDVec128x2Every16& other, EDVec128x2Every16& bestIndices, const EDVec128x2Every16& otherIndices, EDVec128x2Every16& bestAccumDist, const EDVec128x2Every16& otherAccumDist) {
+    __m128i pred0 = _mm_cmpgt_epi16(other.vec_[0], vec_[0]) ; // pred is 0xFFFF if other > this
+    __m128i pred1 = _mm_cmpgt_epi16(other.vec_[1], vec_[1]) ; // pred is 0xFFFF if other > this
+
+    vec_[0] = BLENDV(vec_[0], other.vec_[0], pred0) ; // if pred is 0, choose this; o/w choose other
+    vec_[1] = BLENDV(vec_[1], other.vec_[1], pred1) ; // if pred is 0, choose this; o/w choose other
+
+    bestIndices.vec_[0] = BLENDV(bestIndices.vec_[0], otherIndices.vec_[0], pred0) ;
+    bestIndices.vec_[1] = BLENDV(bestIndices.vec_[1], otherIndices.vec_[1], pred1) ;
+
+    bestAccumDist.vec_[0] = BLENDV(bestAccumDist.vec_[0], otherAccumDist.vec_[0], pred0) ;
+    bestAccumDist.vec_[1] = BLENDV(bestAccumDist.vec_[1], otherAccumDist.vec_[1], pred1) ;
+    
+    return (((uint32_t) _mm_movemask_epi8(pred1)) << 16) | _mm_movemask_epi8(pred0) ;
+  }
+
+  void addThirdIfFirstGTSecond(const EDVec128x2Every16& first, const EDVec128x2Every16& second, 
+			       const EDVec128x2Every16& third, const EDVec128x2Every16& zero) {
+    
+    __m128i pred0 = _mm_cmpgt_epi16(first.vec_[0], second.vec_[1]) ; // pred is 0xFFFF if first > second
+    __m128i pred1 = _mm_cmpgt_epi16(first.vec_[0], second.vec_[1]) ; // pred is 0xFFFF if first > second
+
+    // If pred is 0, then blendv will add zero; o/w it will add third
+    vec_[0] = _mm_add_epi16(vec_[0], BLENDV(zero.vec_[0], third.vec_[0], pred0)) ;
+    vec_[1] = _mm_add_epi16(vec_[1], BLENDV(zero.vec_[1], third.vec_[1], pred1)) ;
+  }
+ 
+  EDVec128x2Every16 subSat(const EDVec128x2Every16& other) const {
+    return EDVec128x2Every16(_mm_subs_epu16(this->vec_[0], other.vec_[0]),
+			     _mm_subs_epu16(this->vec_[1], other.vec_[1])) ;
+  }
+
+  inline void shiftWordsLeftByOne() {
+    vec_[1] = _mm_alignr_epi8(vec_[1], vec_[0], 14) ;
+    vec_[0] = _mm_slli_si128(vec_[0], 2) ; // 16-bit shift = 2 * 8-bit shift
+  }
+  
+  inline bool operator == (const EDVec128x2Every16& other) {
+    return (_mm_movemask_epi8(_mm_cmpeq_epi16(vec_[0], other.vec_[0])) &
+	    _mm_movemask_epi8(_mm_cmpeq_epi16(vec_[1], other.vec_[1]))) == 0xFFFF ;
+  }
+  
+  inline EDVec128x2Every16& operator += (const EDVec128x2Every16& other) {
+    vec_[0] = _mm_add_epi16(vec_[0], other.vec_[0]) ;
+    vec_[1] = _mm_add_epi16(vec_[1], other.vec_[1]) ;
+    return *this ;
+  }
+
+  inline EDVec128x2Every16& operator -= (const EDVec128x2Every16& other) {
+    vec_[0] = _mm_sub_epi16(vec_[0], other.vec_[0]) ;
+    vec_[1] = _mm_sub_epi16(vec_[1], other.vec_[1]) ;
+    return *this ;
+  }
+
+  inline EDVec128x2Every16 operator+ (const EDVec128x2Every16& other) const {
+    return EDVec128x2Every16(_mm_add_epi16(vec_[0], other.vec_[0]),
+			     _mm_add_epi16(vec_[1], other.vec_[1])) ;
+  }
+
+  inline EDVec128x2Every16 operator- (const EDVec128x2Every16& other) const {
+    return EDVec128x2Every16(_mm_sub_epi16(vec_[0], other.vec_[0]),
+			     _mm_sub_epi16(vec_[1], other.vec_[1])) ;
+  }
+
+  inline EDVec128x2Every16 operator* (const EDVec128x2Every16& other) const {
+    return EDVec128x2Every16(_mm_mullo_epi16(vec_[0], other.vec_[0]),
+			     _mm_mullo_epi16(vec_[1], other.vec_[1])) ;
+  }
+
+  inline EDVec128x2Every16 operator& (const EDVec128x2Every16& other) const {
+    return EDVec128x2Every16(_mm_and_si128(vec_[0], other.vec_[0]),
+			     _mm_and_si128(vec_[1], other.vec_[1])) ;
+  }
+
+  static int WORD_CNT() {
+    return WORD_CNT_ ;
+  }
+
+  static int PERIOD() {
+    return PERIOD_ ;
+  }
+
+  friend std::ostream& operator<< (std::ostream& os, const EDVec128x2Every16& v) {
+    os << "{" ;
+    for (int i=0; i < WORD_CNT_; ++i) {
+      os << v.getWord(i) << " " ;
+    }
+    os << "}" ;
+    return os ;
+  }
+
+} ;
+
+
+
+#endif // #ifndef _FAST_EXTEND_VEC128x2_H

--- a/intel_opt/fast_extend_vec256.h
+++ b/intel_opt/fast_extend_vec256.h
@@ -1,0 +1,276 @@
+/* 
+The MIT License (MIT)
+Copyright (c) 2014 Intel Corp.
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef _FAST_EXTEND_VEC256_H
+#define _FAST_EXTEND_VEC256_H
+
+#include <limits>
+
+#include "fast_extend_vec.h"
+#include "fast_extend_bitv128.h"
+#include "fast_extend_bitv128x2.h"
+#include "fast_extend_bitv256.h"
+
+//
+// Edit distance vector for a less-than-255-base query.
+// The probes are at every 16 bases. Each probe is 16 bits.
+// There are 16 probes in total.
+//
+class EDVec256Every16 {
+  __m256i vec_ ;
+  static const int WORD_CNT_ = 16 ;
+  static const int PERIOD_ = 16 ;
+
+ public:
+  EDVec256Every16() {}
+
+  explicit EDVec256Every16(int16_t val) {
+    vec_ = _mm256_set1_epi16(val) ;
+  }
+
+  // gcc complains about undefined _mm256_set_m128i function. 
+  // Commented out this adaptor because it's not really needed.
+  //explicit EDVec256Every16(const BitVec128x2& bv) {
+  //  vec_ = _mm256_set_m128i(bv.bitV[1], bv.bitV[0]) ;
+  //}
+
+#ifdef USE_AVX2
+  explicit EDVec256Every16(__m256i v) {
+    vec_ = v ;
+  }
+
+  explicit EDVec256Every16(const BitVec256& bv) {
+    vec_ = bv.bitV ;
+  }
+#endif
+
+  inline void setAll(int16_t val) {
+    vec_ = _mm256_set1_epi16(val) ;
+  }
+
+  static int16_t getMaxWordVal() { return std::numeric_limits<int16_t>::max() ;}
+
+  inline int getWord(int index) const {
+    switch(index) {
+    case 0: return _mm_extract_epi16(_mm256_castsi256_si128(vec_), 0) ;
+    case 1: return _mm_extract_epi16(_mm256_castsi256_si128(vec_), 1) ;
+    case 2: return _mm_extract_epi16(_mm256_castsi256_si128(vec_), 2) ;
+    case 3: return _mm_extract_epi16(_mm256_castsi256_si128(vec_), 3) ;
+    case 4: return _mm_extract_epi16(_mm256_castsi256_si128(vec_), 4) ;
+    case 5: return _mm_extract_epi16(_mm256_castsi256_si128(vec_), 5) ;
+    case 6: return _mm_extract_epi16(_mm256_castsi256_si128(vec_), 6) ;
+    case 7: return _mm_extract_epi16(_mm256_castsi256_si128(vec_), 7) ;
+
+    case  8: return _mm_extract_epi16(_mm256_extractf128_si256(vec_,1), 0) ;
+    case  9: return _mm_extract_epi16(_mm256_extractf128_si256(vec_,1), 1) ;
+    case 10: return _mm_extract_epi16(_mm256_extractf128_si256(vec_,1), 2) ;
+    case 11: return _mm_extract_epi16(_mm256_extractf128_si256(vec_,1), 3) ;
+    case 12: return _mm_extract_epi16(_mm256_extractf128_si256(vec_,1), 4) ;
+    case 13: return _mm_extract_epi16(_mm256_extractf128_si256(vec_,1), 5) ;
+    case 14: return _mm_extract_epi16(_mm256_extractf128_si256(vec_,1), 6) ;
+    case 15: return _mm_extract_epi16(_mm256_extractf128_si256(vec_,1), 7) ;
+
+    default: assert(false); return 0 ;
+    }
+  }
+
+  bool allLessThanOrEqualTo(const EDVec256Every16& other) const {
+    // Each elt in pred will be set to 0xFFFF if the element in this vector 
+    // is greater than the corresponding element in other
+    __m256i pred = _mm256_cmpgt_epi16(vec_, other.vec_) ; 
+
+    int flags = _mm256_movemask_epi8(pred) ; // creates a mask from MSB of each 8-bit elt in pred
+
+    return flags == 0 ;
+    // if there's at least one elt greater than "other", flags != 0
+  }
+
+  inline void setWords (int* v) {
+    vec_ = _mm256_set_epi16(v[15], v[14], v[13], v[12], v[11], v[10], v[9], v[8],
+			    v[7],  v[6],  v[5],  v[4],  v[3],  v[2],  v[1], v[0]) ;
+  }
+
+  inline void setFirstWord(int val) {
+    vec_ = _mm256_insertf128_si256(vec_,
+				   _mm_insert_epi16(_mm256_castsi256_si128(vec_), val, 0),
+				   0) ;
+  }
+
+  inline void setAllWords (uint16_t val) {
+    vec_ = _mm256_set1_epi16(val) ;
+  }
+
+  inline void setWordsAsMask () {
+    vec_ = _mm256_set1_epi16(0x1) ;
+  }
+
+  static int getLastWordIndexFor (int queryLen) {
+    int baseIndex = queryLen - 1 ;
+    return baseIndex/PERIOD_ ;
+  }
+
+  static int getProbeOffsetFor (int queryLen) {
+    return (queryLen-1) % PERIOD_ ;
+  }
+
+  void setWordsAsEndBonus(int queryLen, int endBonus) {
+    int v[WORD_CNT_] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0} ;
+    
+    int lastWordIndex = getLastWordIndexFor(queryLen) ;    
+    v[lastWordIndex] = endBonus ;
+
+    setWords(v) ;
+  }
+
+  void setWordsAsBadScore(int queryLen, int thr, int infScore) {
+    int v[WORD_CNT_] = {thr, thr, thr, thr, thr, thr, thr, thr, thr, thr, thr, thr, thr, thr, thr, thr} ;
+    
+    int lastWordIndex = getLastWordIndexFor(queryLen) ;    
+    for (int i=lastWordIndex+1; i < WORD_CNT_; ++i) {
+      v[i] = infScore ;
+    }
+
+    setWords(v) ;
+  }
+
+  static int getDistAt(int wordIndex, int queryLen) {
+    return 1 + wordIndex * PERIOD_ + getProbeOffsetFor(queryLen) ;
+  }
+
+  void setWordsAsDist (int queryLen, int distWt) {
+    int v[WORD_CNT_] ;
+    int bitOffset = getProbeOffsetFor(queryLen) ;
+
+    for (int wi=0; wi < WORD_CNT_; ++wi) {
+      v[wi] = distWt * (1 + wi * PERIOD_ + bitOffset) ;
+    }
+    setWords(v) ;
+
+  }
+
+  void setMin(const EDVec256Every16& other) {
+    vec_ = _mm256_min_epi16(vec_, other.vec_) ;
+  }
+
+
+  void setMax(const EDVec256Every16& other, EDVec256Every16& bestIndices, const EDVec256Every16& otherIndices) {
+    __m256i pred = _mm256_cmpgt_epi16(other.vec_, vec_) ; // pred is 0xFFFF if other > this
+
+    vec_ = _mm256_blendv_epi8(vec_, other.vec_, pred) ; // if pred is 0, choose this; o/w choose other
+
+    bestIndices.vec_ = _mm256_blendv_epi8(bestIndices.vec_, otherIndices.vec_, pred) ;
+  }
+
+  void setMax(const EDVec256Every16& other, EDVec256Every16& bestIndices, const EDVec256Every16& otherIndices, EDVec256Every16& bestAccumDist, const EDVec256Every16& otherAccumDist) {
+ 
+   __m256i pred = _mm256_cmpgt_epi16(other.vec_, vec_) ; // pred is 0xFFFF if other > this
+
+    vec_ = _mm256_blendv_epi8(vec_, other.vec_, pred) ; // if pred is 0, choose this; o/w choose other
+
+    bestIndices.vec_ = _mm256_blendv_epi8(bestIndices.vec_, otherIndices.vec_, pred) ;
+
+    bestAccumDist.vec_ = _mm256_blendv_epi8(bestAccumDist.vec_, otherAccumDist.vec_, pred) ;
+  }
+
+  // The return value will be nonzero iff at least one of the entries is updated.
+  // 2 bits per word is returned because of SSE limitations.
+  uint32_t setMaxAndReturnFlag(const EDVec256Every16& other, EDVec256Every16& bestIndices, const EDVec256Every16& otherIndices) {
+    __m256i pred = _mm256_cmpgt_epi16(other.vec_, vec_) ; // pred is 0xFFFF if other > this
+    
+    vec_ = _mm256_blendv_epi8(vec_, other.vec_, pred) ; // if pred is 0, choose this; o/w choose other
+    
+    bestIndices.vec_ = _mm256_blendv_epi8(bestIndices.vec_, otherIndices.vec_, pred) ;
+    
+    return (uint32_t) _mm256_movemask_epi8(pred) ;
+  }
+  
+  // The return value will be nonzero iff at least one of the entries is updated.
+  // 2 bits per word is returned because of SSE limitations.
+  uint32_t setMaxAndReturnFlag(const EDVec256Every16& other, EDVec256Every16& bestIndices, const EDVec256Every16& otherIndices, EDVec256Every16& bestAccumDist, const EDVec256Every16& otherAccumDist) {
+    __m256i pred = _mm256_cmpgt_epi16(other.vec_, vec_) ; // pred is 0xFFFF if other > this
+
+    vec_ = _mm256_blendv_epi8(vec_, other.vec_, pred) ; // if pred is 0, choose this; o/w choose other
+
+    bestIndices.vec_ = _mm256_blendv_epi8(bestIndices.vec_, otherIndices.vec_, pred) ;
+
+    bestAccumDist.vec_ = _mm256_blendv_epi8(bestAccumDist.vec_, otherAccumDist.vec_, pred) ;
+    
+    return ((uint32_t) _mm256_movemask_epi8(pred)) ;
+  }
+
+  void addThirdIfFirstGTSecond(const EDVec256Every16& first, const EDVec256Every16& second, 
+			       const EDVec256Every16& third, const EDVec256Every16& zero) {
+    
+    __m256i pred = _mm256_cmpgt_epi16(first.vec_, second.vec_) ; // pred is 0xFFFF if first > second
+
+    // If pred is 0, then blendv will add zero; o/w it will add third
+    vec_ = _mm256_add_epi16(vec_, _mm256_blendv_epi8(zero.vec_, third.vec_, pred)) ;
+  }
+ 
+  EDVec256Every16 subSat(const EDVec256Every16& other) const {
+    return EDVec256Every16(_mm256_subs_epu16(this->vec_, other.vec_)) ;
+  }
+
+  inline void shiftWordsLeftByOne() {
+    // Shift the vector by 2 bytes (16-bit word) across 128-bit boundary
+    vec_ = _mm256_or_si256(_mm256_slli_si256(vec_, 2),
+			   _mm256_permute4x64_epi64(_mm256_srli_si256(vec_,14), 0x45)) ;
+  }
+  
+  inline bool operator == (const EDVec256Every16& other) {
+    return (uint32_t) _mm256_movemask_epi8(_mm256_cmpeq_epi16(vec_, other.vec_)) == 0xFFFFFFFF ;
+  }
+  
+  inline EDVec256Every16& operator += (const EDVec256Every16& other) {
+    vec_ = _mm256_add_epi16(vec_, other.vec_) ;
+    return *this ;
+  }
+
+  inline EDVec256Every16& operator -= (const EDVec256Every16& other) {
+    vec_ = _mm256_sub_epi16(vec_, other.vec_) ;
+    return *this ;
+  }
+
+  inline EDVec256Every16 operator+ (const EDVec256Every16& other) const {
+    return EDVec256Every16(_mm256_add_epi16(vec_, other.vec_)) ;
+  }
+
+  inline EDVec256Every16 operator- (const EDVec256Every16& other) const {
+    return EDVec256Every16(_mm256_sub_epi16(vec_, other.vec_)) ;
+  }
+
+  inline EDVec256Every16 operator* (const EDVec256Every16& other) const {
+    return EDVec256Every16(_mm256_mullo_epi16(vec_, other.vec_)) ;
+  }
+
+  inline EDVec256Every16 operator& (const EDVec256Every16& other) const {
+    return EDVec256Every16(_mm256_and_si256(vec_, other.vec_)) ;
+  }
+
+  static int WORD_CNT() {
+    return WORD_CNT_ ;
+  }
+
+  static int PERIOD() {
+    return PERIOD_ ;
+  }
+
+  friend std::ostream& operator<< (std::ostream& os, const EDVec256Every16& v) {
+    os << "{" ;
+    for (int i=0; i < WORD_CNT_; ++i) {
+      os << v.getWord(i) << " " ;
+    }
+    os << "}" ;
+    return os ;
+  }
+
+} ;
+
+
+
+#endif // #ifndef _FAST_EXTEND_VEC256_H

--- a/intel_opt/fast_extend_vec32.h
+++ b/intel_opt/fast_extend_vec32.h
@@ -1,0 +1,269 @@
+/* 
+The MIT License (MIT)
+Copyright (c) 2014 Intel Corp.
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef _FAST_EXTEND_VEC32_H
+#define _FAST_EXTEND_VEC32_H
+
+#include "fast_extend_vec.h"
+#include "fast_extend_bitv64.h"
+
+//
+// Edit distance vector for a 32-bit query.
+// 16-bit words will be stored in an SSE vector in interleaved order as follows:
+//           w7 w3 w6 w2 w5 w1 w4 w0
+//
+class EDVec32Every4 {
+  __m128i vec_ ;
+  __m128i shiftLeftIndices_ ; // can be made static later
+  static const int WORD_CNT_ = 8 ;
+  static const int PERIOD_ = 4 ;
+
+  void init_() {
+    shiftLeftIndices_ = _mm_set_epi8(11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 13, 12, 0xFF, 0xFF) ;
+  }
+
+ public:
+  EDVec32Every4() {}
+
+  explicit EDVec32Every4(__m128i v):vec_(v) {init_();}
+  explicit EDVec32Every4(int16_t val):vec_(_mm_set1_epi16(val)) {init_();}
+
+  // The input 32-bit bit-vector corresponds to the query characters. The probes we're interested
+  // in are located at 4-bit intervals. The constructor below stores these 8 probes in a 128-bit
+  // distance vector based on the layout: w7 w3 w6 w2 w5 w1 w4 w0
+  explicit EDVec32Every4(const BitVec64& bv)
+    : vec_(_mm_set_epi32(bv.bitV>>12, bv.bitV>>8, bv.bitV>>4, bv.bitV)) {init_();}
+
+  inline void setAll(int16_t val) {
+    vec_ = _mm_set1_epi16(val) ;    
+  }
+
+  static int16_t getMaxWordVal() { return numeric_limits<int16_t>::max() ;}
+
+  inline int getWord(int index) const {
+    switch(index) {
+    case 0: return _mm_extract_epi16(vec_, 0) ;
+    case 1: return  _mm_extract_epi16(vec_, 2) ;
+    case 2: return  _mm_extract_epi16(vec_, 4) ;
+    case 3: return  _mm_extract_epi16(vec_, 6) ;
+    case 4: return  _mm_extract_epi16(vec_, 1) ;
+    case 5: return  _mm_extract_epi16(vec_, 3) ;
+    case 6: return  _mm_extract_epi16(vec_, 5) ;
+    case 7: return  _mm_extract_epi16(vec_, 7) ;
+    default: assert(false); return 0 ;
+    }
+  }
+
+  bool allLessThanOrEqualTo(const EDVec32Every4& other) const {
+    // each elt in pred will be set to 0xFFFF if the element in this vector 
+    // is greater than the corresponding element in other
+    __m128i pred = _mm_cmpgt_epi16(vec_, other.vec_) ; 
+    int flags = _mm_movemask_epi8(pred) ; // creates a mask from MSB of each 8-bit elt in pred
+
+    return flags == 0 ; // if there's at least one elt greater than "other", flags != 0
+  }
+
+
+  inline void setWords (int* v) {
+    vec_ = _mm_set_epi16(v[7], v[3], v[6], v[2], v[5], v[1], v[4], v[0]) ;
+  }
+
+  inline void setAllWords (uint16_t val) {
+    vec_ = _mm_set1_epi16(val) ;
+  }
+
+  inline void setFirstWord(int val) {
+    vec_ = _mm_insert_epi16(vec_, val, 0) ;
+  }
+
+  inline void setWordsAsMask () {
+    vec_ = _mm_set1_epi16(0x1) ;
+  }
+
+
+  static int getLastWordIndexFor (int queryLen) {
+    return (queryLen-1) / PERIOD_ ; // logical word index - no interleaving at this level
+  }
+
+  static int getProbeOffsetFor (int queryLen) {
+    return (queryLen-1) % PERIOD_ ;
+  }
+
+  void setWordsAsEndBonus(int queryLen, int endBonus) {
+    int v[WORD_CNT_] = {0, 0, 0, 0, 0, 0, 0, 0} ;
+    
+    int lastWordIndex = getLastWordIndexFor(queryLen) ;    
+    v[lastWordIndex] = endBonus ;
+
+    setWords(v) ;
+  }
+
+  void setWordsAsBadScore(int queryLen, int thr, int infScore) {
+    int v[WORD_CNT_] = {thr, thr, thr, thr, thr, thr, thr, thr} ;
+    
+    int lastWordIndex = getLastWordIndexFor(queryLen) ;    
+    for (int i=lastWordIndex+1; i < WORD_CNT_; ++i)
+      v[i] = infScore ;
+
+    setWords(v) ;
+  }
+
+  static int getDistAt(int wordIndex, int queryLen) {
+    return wordIndex * PERIOD_ + getProbeOffsetFor(queryLen) + 1 ;
+  }
+
+  void setWordsAsDist (int queryLen, int distWt) {
+    int v[WORD_CNT_] ;
+    int bitOffset = getProbeOffsetFor(queryLen) ;
+    
+    for (int wi=0; wi < WORD_CNT_; ++wi) {
+      v[wi] = distWt * (wi * PERIOD_ + bitOffset + 1) ;
+    }
+
+    setWords(v) ;
+  }
+
+  void setMin(const EDVec32Every4& other) {
+    vec_ = _mm_min_epi16(vec_, other.vec_) ;
+  }
+
+  void setMin(const EDVec32Every4& other, EDVec32Every4& bestIndices, const EDVec32Every4& otherIndices) {
+    __m128i pred = _mm_cmplt_epi16(other.vec_, vec_) ; // pred is 0xFFFF if other < this
+    vec_ = BLENDV(vec_, other.vec_, pred) ; // if pred is 0, choose this; o/w choose other
+    bestIndices.vec_ = BLENDV(bestIndices.vec_, otherIndices.vec_, pred) ;
+  }
+
+  void setMax(const EDVec32Every4& other, EDVec32Every4& bestIndices, const EDVec32Every4& otherIndices) {
+    __m128i pred = _mm_cmpgt_epi16(other.vec_, vec_) ; // pred is 0xFFFF if other > this
+    vec_ = BLENDV(vec_, other.vec_, pred) ; // if pred is 0, choose this; o/w choose other
+    bestIndices.vec_ = BLENDV(bestIndices.vec_, otherIndices.vec_, pred) ;
+  }
+
+  void setMax(const EDVec32Every4& other, EDVec32Every4& bestIndices, const EDVec32Every4& otherIndices, EDVec32Every4& bestAccumDist, const EDVec32Every4& otherAccumDist) {
+    __m128i pred = _mm_cmpgt_epi16(other.vec_, vec_) ; // pred is 0xFFFF if other > this
+    vec_ = BLENDV(vec_, other.vec_, pred) ; // if pred is 0, choose this; o/w choose other
+    bestIndices.vec_ = BLENDV(bestIndices.vec_, otherIndices.vec_, pred) ;
+    bestAccumDist.vec_ = BLENDV(bestAccumDist.vec_, otherAccumDist.vec_, pred) ;
+  }
+
+  // The return value will be nonzero iff at least one of the entries is updated.
+  // 2 bits per word is returned because of SSE limitations.
+  uint32_t setMaxAndReturnFlag(const EDVec32Every4& other, EDVec32Every4& bestIndices, const EDVec32Every4& otherIndices) {
+    __m128i pred = _mm_cmpgt_epi16(other.vec_, vec_) ; // pred is 0xFFFF if other > this
+    vec_ = BLENDV(vec_, other.vec_, pred) ; // if pred is 0, choose this; o/w choose other
+    bestIndices.vec_ = BLENDV(bestIndices.vec_, otherIndices.vec_, pred) ;
+    return (uint32_t) _mm_movemask_epi8(pred) ;
+  }
+
+  // The return value will be nonzero iff at least one of the entries is updated.
+  // 2 bits per word is returned because of SSE limitations.
+  uint32_t setMaxAndReturnFlag(const EDVec32Every4& other, EDVec32Every4& bestIndices, const EDVec32Every4& otherIndices, EDVec32Every4& bestAccumDist, const EDVec32Every4& otherAccumDist) {
+    __m128i pred = _mm_cmpgt_epi16(other.vec_, vec_) ; // pred is 0xFFFF if other > this
+    vec_ = BLENDV(vec_, other.vec_, pred) ; // if pred is 0, choose this; o/w choose other
+    bestIndices.vec_ = BLENDV(bestIndices.vec_, otherIndices.vec_, pred) ;
+    bestAccumDist.vec_ = BLENDV(bestAccumDist.vec_, otherAccumDist.vec_, pred) ; 
+
+   return (uint32_t) _mm_movemask_epi8(pred) ;
+  }
+
+
+  void addThirdIfFirstGTSecond(const EDVec32Every4& first, const EDVec32Every4& second, 
+			       const EDVec32Every4& third, const EDVec32Every4& zero) {
+
+    __m128i pred = _mm_cmpgt_epi16(first.vec_, second.vec_) ; 
+    // pred is 0xFFFF if first > second
+
+    // If pred is 0, then blendv will add zero; o/w it will add third
+    vec_ = _mm_add_epi16(vec_, BLENDV(zero.vec_, third.vec_, pred)) ;
+  }
+
+  EDVec32Every4 subSat(const EDVec32Every4& other) const {
+    return EDVec32Every4(_mm_subs_epu16(this->vec_, other.vec_)) ;
+  }
+
+  inline EDVec32Every4 shiftBitsRightWithinWords(int shiftVal) {
+    return EDVec32Every4(_mm_srli_epi16(vec_, shiftVal)) ;
+  }
+
+  inline void shiftWordsLeftByOne() {
+    //vec_ = _mm_slli_si128(vec_, 2) ; // 16-bit shift = 2 * 8-bit shift
+
+#ifdef USE_SSE4
+    vec_ = _mm_shuffle_epi8(vec_, shiftLeftIndices_) ;
+
+#else
+
+    // The layout of the logical 16-bit words before shift:
+    // 7 3 6 2 5 1 4 0
+    // Consider the physical 16-bit words before shift: 
+    // 7 6 5 4 3 2 1 0
+    // These words should be shuffled into the following for logical shift:
+    // 5 4 3 2 1 0 6 X
+    
+    // First, do the following: 7 6 5 4 3 2 1 0 --> 5 4 3 2 1 0 7 6
+    // The binary imm value: 10 01 00 11 (i.e. 2 1 0 3)
+    vec_ = _mm_shuffle_epi32(vec_, 0x93) ;
+
+    // Then, do the following: 5 4 3 2 1 0 7 6 --> 5 4 3 2 1 0 6 7
+    // The binary imm value: 11 10 00 01 (i.e. 3 2 0 1)
+    vec_ = _mm_shufflelo_epi16(vec_, 0xE1) ;
+#endif // #ifdef USE_SSE4
+
+  }
+
+  inline bool operator == (const EDVec32Every4& other) {
+    return _mm_movemask_epi8(_mm_cmpeq_epi16(vec_, other.vec_)) == 0xFFFF ;
+  }
+
+  inline EDVec32Every4& operator += (const EDVec32Every4& other) {
+    vec_ = _mm_add_epi16(vec_, other.vec_) ;
+    return *this ;
+  }
+
+  inline EDVec32Every4& operator -= (const EDVec32Every4& other) {
+    vec_ = _mm_sub_epi16(vec_, other.vec_) ;
+    return *this ;
+  }
+
+  inline EDVec32Every4 operator+ (const EDVec32Every4& other) const {
+    return EDVec32Every4(_mm_add_epi16(vec_, other.vec_)) ;
+  }
+
+  inline EDVec32Every4 operator- (const EDVec32Every4& other) const {
+    return EDVec32Every4(_mm_sub_epi16(vec_, other.vec_)) ;
+  }
+
+  inline EDVec32Every4 operator* (const EDVec32Every4& other) const {
+    return EDVec32Every4(_mm_mullo_epi16(vec_, other.vec_)) ;
+  }
+
+  inline EDVec32Every4 operator& (const EDVec32Every4& other) const {
+    return EDVec32Every4(_mm_and_si128(vec_, other.vec_)) ;
+  }
+
+  static int WORD_CNT() {
+    return WORD_CNT_ ;
+  }
+
+  static int PERIOD() {
+    return PERIOD_ ;
+  }
+
+  friend std::ostream& operator<< (std::ostream& os, const EDVec32Every4& v) {
+    os << "{" ;
+    for (int i=0; i < WORD_CNT_; ++i) {
+      os << v.getWord(i) << " " ;
+    }
+    os << "}" ;
+    return os ;
+  }
+
+} ;
+
+
+#endif // #ifndef _FAST_EXTEND_VEC32_H

--- a/intel_opt/fast_extend_vec64.h
+++ b/intel_opt/fast_extend_vec64.h
@@ -1,0 +1,269 @@
+/* 
+The MIT License (MIT)
+Copyright (c) 2014 Intel Corp.
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef _FAST_EXTEND_VEC64_H
+#define _FAST_EXTEND_VEC64_H
+
+#include "fast_extend_vec.h"
+#include "fast_extend_bitv64.h"
+
+//
+// Edit distance vector for a 64-bit query.
+// 16-bit words will be stored in an SSE vector in interleaved order as follows:
+//           w7 w5 w3 w1 w6 w4 w2 w0
+//
+class EDVec64Every8 {
+  __m128i vec_ ;
+  __m128i shiftLeftIndices_ ; // can be made static later
+  static const int WORD_CNT_ = 8 ;
+  static const int PERIOD_ = 8 ;
+
+  void init_() {
+    shiftLeftIndices_ = _mm_set_epi8(7, 6, 5, 4, 3, 2, 1, 0, 13, 12, 11, 10, 9, 8, 0xFF, 0xFF) ;
+  }
+
+
+ public:
+  EDVec64Every8() {}
+
+  explicit EDVec64Every8(__m128i v):vec_(v) {init_() ;}
+  explicit EDVec64Every8(int16_t val):vec_(_mm_set1_epi16(val)) {init_() ;}
+
+  // The input 64-bit bit-vector corresponds to the query characters. The probes we're interested
+  // in are located at 8-bit intervals. The constructor below stores these 8 probes in a 128-bit
+  // distance vector based on the layout: w7 w5 w3 w1 w6 w4 w2 w0.
+  explicit EDVec64Every8(const BitVec64& bv): vec_(_mm_set_epi64x(bv.bitV>>8, bv.bitV)) {init_() ;}
+
+  inline void setAll(int16_t val) {
+    vec_ = _mm_set1_epi16(val) ;    
+  }
+
+  static int16_t getMaxWordVal() { return numeric_limits<int16_t>::max() ;}
+
+  inline int getWord(int index) const {
+    switch(index) {
+    case 0: return _mm_extract_epi16(vec_, 0) ;
+    case 1: return  _mm_extract_epi16(vec_, 4) ;
+    case 2: return  _mm_extract_epi16(vec_, 1) ;
+    case 3: return  _mm_extract_epi16(vec_, 5) ;
+    case 4: return  _mm_extract_epi16(vec_, 2) ;
+    case 5: return  _mm_extract_epi16(vec_, 6) ;
+    case 6: return  _mm_extract_epi16(vec_, 3) ;
+    case 7: return  _mm_extract_epi16(vec_, 7) ;
+    default: assert(false); return 0 ;
+    }
+  }
+
+  bool allLessThanOrEqualTo(const EDVec64Every8& other) const {
+    // each elt in pred will be set to 0xFFFF if the element in this vector 
+    // is greater than the corresponding element in other
+    __m128i pred = _mm_cmpgt_epi16(vec_, other.vec_) ; 
+    int flags = _mm_movemask_epi8(pred) ; // creates a mask from MSB of each 8-bit elt in pred
+
+    return flags == 0 ; // if there's at least one elt greater than "other", flags != 0
+  }
+  
+  inline void setWords (int* v) {
+    vec_ = _mm_set_epi16(v[7], v[5], v[3], v[1], v[6], v[4], v[2], v[0]) ;
+  }
+
+  inline void setFirstWord(int val) {
+    vec_ = _mm_insert_epi16(vec_, val, 0) ;
+  }
+
+  inline void setAllWords (uint16_t val) {
+    vec_ = _mm_set1_epi16(val) ;
+  }
+
+  inline void setWordsAsMask () {
+    vec_ = _mm_set1_epi16(0x1) ;
+  }
+
+  static int getLastWordIndexFor (int queryLen) {
+    return (queryLen-1) / PERIOD_ ; // logical word index - no interleaving at this level
+  }
+
+  static int getProbeOffsetFor (int queryLen) {
+    return (queryLen-1) % PERIOD_ ;
+  }
+
+  void setWordsAsEndBonus(int queryLen, int endBonus) {
+    int v[WORD_CNT_] = {0, 0, 0, 0, 0, 0, 0, 0} ;
+    
+    int lastWordIndex = getLastWordIndexFor(queryLen) ;    
+    v[lastWordIndex] = endBonus ;
+
+    setWords(v) ;
+  }
+
+  void setWordsAsBadScore(int queryLen, int thr, int infScore) {
+    int v[WORD_CNT_] = {thr, thr, thr, thr, thr, thr, thr, thr} ;
+    
+    int lastWordIndex = getLastWordIndexFor(queryLen) ;    
+    for (int i=lastWordIndex+1; i < WORD_CNT_; ++i) {
+      v[i] = infScore ;
+    }
+
+    setWords(v) ;
+  }
+
+  static int getDistAt(int wordIndex, int queryLen) {
+    return wordIndex * PERIOD_ + getProbeOffsetFor(queryLen) + 1 ;
+  }
+
+  void setWordsAsDist (int queryLen, int distWt) {
+    int v[WORD_CNT_] ;
+    int bitOffset = getProbeOffsetFor(queryLen) ;
+    
+    for (int wi=0; wi < WORD_CNT_; ++wi) {
+      v[wi] = distWt * (wi * PERIOD_ + bitOffset + 1) ;
+    }
+
+    setWords(v) ;
+  }
+
+  void setMin(const EDVec64Every8& other) {
+    vec_ = _mm_min_epi16(vec_, other.vec_) ;
+  }
+
+  void setMin(const EDVec64Every8& other, EDVec64Every8& bestIndices, const EDVec64Every8& otherIndices) {
+    __m128i pred = _mm_cmplt_epi16(other.vec_, vec_) ; // pred is 0xFFFF if other < this
+    vec_ = BLENDV(vec_, other.vec_, pred) ; // if pred is 0, choose this; o/w choose other
+    bestIndices.vec_ = BLENDV(bestIndices.vec_, otherIndices.vec_, pred) ;
+  }
+
+  void setMax(const EDVec64Every8& other, EDVec64Every8& bestIndices, const EDVec64Every8& otherIndices) {
+    __m128i pred = _mm_cmpgt_epi16(other.vec_, vec_) ; // pred is 0xFFFF if other > this
+    vec_ = BLENDV(vec_, other.vec_, pred) ; // if pred is 0, choose this; o/w choose other
+    bestIndices.vec_ = BLENDV(bestIndices.vec_, otherIndices.vec_, pred) ;
+  }
+
+  void setMax(const EDVec64Every8& other, EDVec64Every8& bestIndices, const EDVec64Every8& otherIndices, EDVec64Every8& bestAccumDist, const EDVec64Every8& otherAccumDist) {
+    __m128i pred = _mm_cmpgt_epi16(other.vec_, vec_) ; // pred is 0xFFFF if other > this
+    vec_ = BLENDV(vec_, other.vec_, pred) ; // if pred is 0, choose this; o/w choose other
+    bestIndices.vec_ = BLENDV(bestIndices.vec_, otherIndices.vec_, pred) ;
+    bestAccumDist.vec_ = BLENDV(bestAccumDist.vec_, otherAccumDist.vec_, pred) ;
+  }
+
+
+  // The return value will be nonzero iff at least one of the entries is updated.
+  // 2 bits per word is returned because of SSE limitations.
+  uint32_t setMaxAndReturnFlag(const EDVec64Every8& other, EDVec64Every8& bestIndices, const EDVec64Every8& otherIndices) {
+    __m128i pred = _mm_cmpgt_epi16(other.vec_, vec_) ; // pred is 0xFFFF if other > this
+    vec_ = BLENDV(vec_, other.vec_, pred) ; // if pred is 0, choose this; o/w choose other
+    bestIndices.vec_ = BLENDV(bestIndices.vec_, otherIndices.vec_, pred) ;
+    return (uint32_t) _mm_movemask_epi8(pred) ;
+  }
+
+  // The return value will be nonzero iff at least one of the entries is updated.
+  // 2 bits per word is returned because of SSE limitations.
+  uint32_t setMaxAndReturnFlag(const EDVec64Every8& other, EDVec64Every8& bestIndices, const EDVec64Every8& otherIndices, EDVec64Every8& bestAccumDist, const EDVec64Every8& otherAccumDist) {
+    __m128i pred = _mm_cmpgt_epi16(other.vec_, vec_) ; // pred is 0xFFFF if other > this
+    vec_ = BLENDV(vec_, other.vec_, pred) ; // if pred is 0, choose this; o/w choose other
+    bestIndices.vec_ = BLENDV(bestIndices.vec_, otherIndices.vec_, pred) ;
+    bestAccumDist.vec_ = BLENDV(bestAccumDist.vec_, otherAccumDist.vec_, pred) ;
+ 
+   return (uint32_t) _mm_movemask_epi8(pred) ;
+  }
+
+  void addThirdIfFirstGTSecond(const EDVec64Every8& first, const EDVec64Every8& second, 
+			       const EDVec64Every8& third, const EDVec64Every8& zero) {
+
+    __m128i pred = _mm_cmpgt_epi16(first.vec_, second.vec_) ; 
+    // pred is 0xFFFF if first > second
+
+    // If pred is 0, then blendv will add zero; o/w it will add third
+    vec_ = _mm_add_epi16(vec_, BLENDV(zero.vec_, third.vec_, pred)) ;
+  }
+
+  EDVec64Every8 subSat(const EDVec64Every8& other) const {
+    return EDVec64Every8(_mm_subs_epu16(this->vec_, other.vec_)) ;
+  }
+
+  inline EDVec64Every8 shiftBitsRightWithinWords(int shiftVal) {
+    return EDVec64Every8(_mm_srli_epi16(vec_, shiftVal)) ;
+  }
+
+  inline void shiftWordsLeftByOne() {
+
+#ifdef USE_SSE4
+    vec_ = _mm_shuffle_epi8(vec_, shiftLeftIndices_) ;
+#else
+
+    // The layout of the logical 16-bit words before shift:
+    // 7 5 3 1 6 4 2 0
+    // Consider the physical 16-bit words before shift: 
+    // 7 6 5 4 3 2 1 0
+    // These words should be shuffled into the following for logical shift:
+    // 3 2 1 0 6 5 4 X
+    
+    // First, do the following: 7 6 5 4 3 2 1 0 --> 6 5 4 7 3 2 1 0
+    // The binary imm value: 10 01 00 11 (i.e. 2 1 0 3)
+    vec_ = _mm_shufflehi_epi16(vec_, 0x93) ;
+
+    // Then, do the following: 6 5 4 7 3 2 1 0 --> 3 2 1 0 6 5 4 7
+    // The binary imm value: 01 00 11 10 (i.e. 1 0 3 2)
+    vec_ = _mm_shuffle_epi32(vec_, 0x4E) ;
+
+#endif // #ifdef USE_SSE4
+
+  }
+
+  inline bool operator == (const EDVec64Every8& other) {
+    return _mm_movemask_epi8(_mm_cmpeq_epi16(vec_, other.vec_)) == 0xFFFF ;
+  }
+
+  inline EDVec64Every8& operator += (const EDVec64Every8& other) {
+    vec_ = _mm_add_epi16(vec_, other.vec_) ;
+    return *this ;
+  }
+
+  inline EDVec64Every8& operator -= (const EDVec64Every8& other) {
+    vec_ = _mm_sub_epi16(vec_, other.vec_) ;
+    return *this ;
+  }
+
+  inline EDVec64Every8 operator+ (const EDVec64Every8& other) const {
+    return EDVec64Every8(_mm_add_epi16(vec_, other.vec_)) ;
+  }
+
+  inline EDVec64Every8 operator- (const EDVec64Every8& other) const {
+    return EDVec64Every8(_mm_sub_epi16(vec_, other.vec_)) ;
+  }
+
+  inline EDVec64Every8 operator* (const EDVec64Every8& other) const {
+    return EDVec64Every8(_mm_mullo_epi16(vec_, other.vec_)) ;
+  }
+
+  inline EDVec64Every8 operator& (const EDVec64Every8& other) const {
+    return EDVec64Every8(_mm_and_si128(vec_, other.vec_)) ;
+  }
+
+  static int WORD_CNT() {
+    return WORD_CNT_ ;
+  }
+
+  static int PERIOD() {
+    return PERIOD_ ;
+  }
+
+  friend std::ostream& operator<< (std::ostream& os, const EDVec64Every8& v) {
+    os << "{" ;
+    for (int i=0; i < WORD_CNT_; ++i) {
+      os << v.getWord(i) << " " ;
+    }
+    os << "}" ;
+    return os ;
+  }
+
+} ;
+
+
+
+
+#endif // #ifndef _FAST_EXTEND_VEC64_H

--- a/main.c
+++ b/main.c
@@ -4,7 +4,7 @@
 #include "utils.h"
 
 #ifndef PACKAGE_VERSION
-#define PACKAGE_VERSION "0.7.17-r1194-dirty"
+#define PACKAGE_VERSION "0.7.17-r1194-intel-extend"
 #endif
 
 int bwa_fa2pac(int argc, char *argv[]);


### PR DESCRIPTION
Using the `-F` flag that this patch provides, bwa mem finishes in 80% of the time using SSE4, (more speedup with AVX)