### PR TITLE
Fix potential assertion in bntseq fails #120

### DIFF
--- a/bntseq.c
+++ b/bntseq.c
@@ -442,6 +442,7 @@ uint8_t *bns_fetch_seq(const bntseq_t *bns, const uint8_t *pac, int64_t *beg, in
 	}
 	*beg = *beg > far_beg? *beg : far_beg;
 	*end = *end < far_end? *end : far_end;
+	if (*end < *beg) *end ^= *beg, *beg ^= *end, *end ^= *beg; // if end is smaller, swap
 	seq = bns_get_seq(bns->l_pac, pac, *beg, *end, &len);
 	if (seq == 0 || *end - *beg != len) {
 		fprintf(stderr, "[E::%s] begin=%ld, mid=%ld, end=%ld, len=%ld, seq=%p, rid=%d, far_beg=%ld, far_end=%ld\n",


### PR DESCRIPTION
Sometime, both `*beg` and `*end` may be larger than `far_beg` and `far_end`, and this will cause `*end` be assigned to `far_end` (in line 444), and then crash in `assert()` in line 450.