### PR TITLE
Update Makefile to work with Bioconda

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CC=			gcc
 CFLAGS=		-g -Wall -Wno-unused-function -O2
 WRAP_MALLOC=-DUSE_MALLOC_WRAPPERS
 AR=			ar
-DFLAGS=		-DHAVE_PTHREAD $(WRAP_MALLOC)
+DFLAGS=		-DHAVE_PTHREAD $(WRAP_MALLOC) $(LDFLAGS)
 LOBJS=		utils.o kthread.o kstring.o ksw.o bwt.o bntseq.o bwa.o bwamem.o bwamem_pair.o bwamem_extra.o malloc_wrap.o \
 			QSufSort.o bwt_gen.o rope.o rle.o is.o bwtindex.o
 AOBJS=		bwashm.o bwase.o bwaseqio.o bwtgap.o bwtaln.o bamlite.o \


### PR DESCRIPTION
This update will allow bwa to be compiled correctly on bioconda with its new compiler environmental rules.