### PR TITLE
Update bwape.c

### DIFF
--- a/bwape.c
+++ b/bwape.c
@@ -165,7 +165,7 @@ static int pairing(bwa_seq_t *p[2], pe_data_t *d, const pe_opt_t *opt, int s_mm,
 	// here v>=u. When ii is set, we check insert size with ii; otherwise with opt->max_isize
 #define __pairing_aux(u,v) do { \
 		bwtint_t l = (v).x + p[(v).y&1]->len - ((u).x); \
-		if ((u).x != (uint64_t)-1 && (v).x > (u).x && l >= max_len \
+		if ((u).x != (uint64_t)-1 && (v).x >= (u).x && l >= max_len \
 			&& ((ii->high && l <= ii->high_bayesian) || (ii->high == 0 && l <= opt->max_isize))) \
 		{ \
 			uint64_t s = d->aln[(v).y&1].a[(v).y>>2].score + d->aln[(u).y&1].a[(u).y>>2].score; \


### PR DESCRIPTION
Pre-processing tools like _AfterQC_ and _fastp_ can perform adapter clipping leaving both reads in a pair identical. This leads them to be mapped at the same location by `aln`, leading to `(v).x == (u).x` in the code below. The proposed change allows `sampe` to flag these as mapped in the proper pair.

Using some test data, this is a distribution of fragment lengths, pre-processed using _fastp_, mapped with `aln` and paired with `sampe` using the original code. Blue indicates mapped in proper pair (0x2 True) and red indicated otherwise (0x2 False).

![test3](https://user-images.githubusercontent.com/33732220/69586920-e6cf1c80-0f98-11ea-8e04-f8abe4ed4492.png)

This is the same distribution with the proposed change:

![test4](https://user-images.githubusercontent.com/33732220/69586968-0108fa80-0f99-11ea-8835-be2877c3086f.png)

Thanks,
Andre