### PR TITLE
Makefile: Use $CPPFLAGS and $LDFLAGS if they are set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,15 +22,15 @@ endif
 .SUFFIXES:.c .o .cc
 
 .c.o:
-		$(CC) -c $(CFLAGS) $(DFLAGS) $(INCLUDES) $< -o $@
+		$(CC) -c $(CFLAGS) $(DFLAGS) $(INCLUDES) $(CPPFLAGS) $< -o $@
 
 all:$(PROG)
 
 bwa:libbwa.a $(AOBJS) main.o
-		$(CC) $(CFLAGS) $(DFLAGS) $(AOBJS) main.o -o $@ -L. -lbwa $(LIBS)
+		$(CC) $(CFLAGS) $(LDFLAGS) $(AOBJS) main.o -o $@ -L. -lbwa $(LIBS)
 
 bwamem-lite:libbwa.a example.o
-		$(CC) $(CFLAGS) $(DFLAGS) example.o -o $@ -L. -lbwa $(LIBS)
+		$(CC) $(CFLAGS) $(LDFLAGS) example.o -o $@ -L. -lbwa $(LIBS)
 
 libbwa.a:$(LOBJS)
 		$(AR) -csru $@ $(LOBJS)
@@ -39,7 +39,7 @@ clean:
 		rm -f gmon.out *.o a.out $(PROG) *~ *.a
 
 depend:
-	( LC_ALL=C ; export LC_ALL; makedepend -Y -- $(CFLAGS) $(DFLAGS) -- *.c )
+	( LC_ALL=C ; export LC_ALL; makedepend -Y -- $(CFLAGS) $(DFLAGS) $(CPPFLAGS) -- *.c )
 
 # DO NOT DELETE THIS LINE -- make depend depends on it.
 


### PR DESCRIPTION
Makefile convention is to use CC/CPPFLAGS/CFLAGS/LDFLAGS/LIBS variables in the compile and link rules. This adds `$(CPPFLAGS)` and `$(LDFLAGS)` to the appropriate rules, so that these two can also be used to customise the build in the expected conventional way — in addition to the already present `$(CC)`, `$(CFLAGS)`, and `$(LIBS)`.

In particular, bioconda and Debian would take advantage of these variables in their packaging scripts. Supersedes and closes #247.