### PR TITLE
GCC 10 and Makefile fixes

### DIFF
--- a/rle.h
+++ b/rle.h
@@ -30,7 +30,7 @@ extern "C" {
  *** 43+3 codec ***
  ******************/
 
-const uint8_t rle_auxtab[8];
+extern const uint8_t rle_auxtab[8];
 
 #define RLE_MIN_SPACE 18
 #define rle_nptr(block) ((uint16_t*)(block))


### PR DESCRIPTION
Hi @lh3,
This PR includes a patch for the upcoming GCC 10, which imports C++'s ODR rule to C too.
I've also fixed the Makefile a bit so we don't have to patch it downstream. `CC` and `AR` don't need to be defined, `make` will use `cc` and `gcc` in their place. By omitting the definition, we don't have to hack the Makefile because we export `CC` and `AR` to the environment, which Make looks for before using the fallbacks.