### PR TITLE
set optimization from -O2 to -O3, 3.4 % performance increase observed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC=			gcc
 #CC=			clang --analyze
-CFLAGS=		-g -Wall -Wno-unused-function -O2
+CFLAGS=		-g -Wall -Wno-unused-function -O3
 WRAP_MALLOC=-DUSE_MALLOC_WRAPPERS
 AR=			ar
 DFLAGS=		-DHAVE_PTHREAD $(WRAP_MALLOC)


### PR DESCRIPTION
I've seen a runtime decrease of 3.4% on average over three runs in one example raising the optimization level from -O2 to -O3 in gcc.

bwa uses lots of bit shift operators. It seems -O3 makes a difference here, see this trivial example:
https://www.godbolt.org/z/jD_cC5

I aligned one million reads to a mm10 using the command line
`bwa aln -t 4 -f reads.sai mm10.fa Andreas_BWA/SRR1519948.1_1000000.fastq`
Time went down from 62.8s to 60.6s.