### PR TITLE
travis: added arm64, ppc64le and s390x tests with simde

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lib/simde"]
+	path = lib/simde
+	url = https://github.com/nemequ/simde.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,20 @@
-language: c
-compiler:
-  - gcc
-  - clang
-script: make
+matrix:
+  include:
+    - language: c
+      compiler: gcc
+      script: make
+    - language: c
+      compiler: clang
+      script: make
+    - arch: arm64
+      language: c
+      compiler: gcc
+      script: make simde=1
+    - arch: ppc64le
+      language: c
+      compiler: gcc
+      script: make simde=1
+    - arch: s390x
+      language: c
+      compiler: gcc
+      script: make simde=1

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,11 @@ INCLUDES=
 LIBS=		-lm -lz -lpthread
 SUBDIRS=	.
 
+ifneq ($(simde),)
+	CFLAGS += -DUSE_SIMDE -DSIMDE_ENABLE_NATIVE_ALIASES -DSIMDE_ENABLE_OPENMP -fopenmp-simd
+	INCLUDES += -Ilib/simde
+endif
+
 ifeq ($(shell uname -s),Linux)
 	LIBS += -lrt
 endif

--- a/ksw.c
+++ b/ksw.c
@@ -26,7 +26,11 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <assert.h>
+#ifdef USE_SIMDE
+#include <simde/x86/sse2.h>
+#else
 #include <emmintrin.h>
+#endif
 #include "ksw.h"
 
 #ifdef USE_MALLOC_WRAPPERS


### PR DESCRIPTION
This PR is to add arm64, ppc64le and s390x tests with simde.

I referred Debian's [Makefile](https://salsa.debian.org/med-team/bwa/-/blob/master/debian/rules#L4) and the [patch](https://salsa.debian.org/med-team/bwa/-/blob/master/debian/patches/simde) to use simde, as there are Debian's bwa deb packages on some CPU architectures [here](https://packages.debian.org/sid/bwa).

For `.travis.yml` and how to implement simde, I referred minimap2.

This PR also fixes https://github.com/lh3/bwa/issues/77 and https://github.com/lh3/bwa/pull/71 .

Travis is ok [here](https://travis-ci.org/github/lh3/bwa/builds/688121496).