### PR TITLE
add option to bwa mem to generate 'ms' and 'MQ' tag for 'samtools markdup' if needed and  remove redundant and misleading code

### DIFF
--- a/bwamem.c
+++ b/bwamem.c
@@ -848,7 +848,7 @@ static inline void add_cigar(const mem_opt_t *opt, mem_aln_t *p, kstring_t *str,
 	} else kputc('*', str); // having a coordinate but unaligned (e.g. when copy_mate is true)
 }
 
-void mem_aln2sam(const mem_opt_t *opt, const bntseq_t *bns, kstring_t *str, bseq1_t *s, int n, const mem_aln_t *list, int which, const mem_aln_t *m_)
+void mem_aln2sam(const mem_opt_t *opt, const bntseq_t *bns, kstring_t *str, bseq1_t *s, int n, const mem_aln_t *list, int which, const mem_aln_t *m_, int ms)
 {
 	int i, l_name;
 	mem_aln_t ptmp = list[which], *p = &ptmp, mtmp, *m = 0; // make a copy of the alignment to convert
@@ -932,6 +932,8 @@ void mem_aln2sam(const mem_opt_t *opt, const bntseq_t *bns, kstring_t *str, bseq
 		kputsn("\tMD:Z:", 6, str); kputs((char*)(p->cigar + p->n_cigar), str);
 	}
 	if (m && m->n_cigar) { kputsn("\tMC:Z:", 6, str); add_cigar(opt, m, str, which); }
+    if (m) { kputsn("\tMQ:i:", 6, str); kputw(m->mapq, str); }
+    if (m && opt->flag & MEM_F_MS) { kputsn("\tms:i:", 6, str); kputw(ms, str); }
 	if (p->score >= 0) { kputsn("\tAS:i:", 6, str); kputw(p->score, str); }
 	if (p->sub >= 0) { kputsn("\tXS:i:", 6, str); kputw(p->sub, str); }
 	if (bwa_rg_id[0]) { kputsn("\tRG:Z:", 6, str); kputs(bwa_rg_id, str); }
@@ -1063,10 +1065,10 @@ void mem_reg2sam(const mem_opt_t *opt, const bntseq_t *bns, const uint8_t *pac, 
 		mem_aln_t t;
 		t = mem_reg2aln(opt, bns, pac, s->l_seq, s->seq, 0);
 		t.flag |= extra_flag;
-		mem_aln2sam(opt, bns, &str, s, 1, &t, 0, m);
+		mem_aln2sam(opt, bns, &str, s, 1, &t, 0, m, 0);
 	} else {
 		for (k = 0; k < aa.n; ++k)
-			mem_aln2sam(opt, bns, &str, s, aa.n, aa.a, k, m);
+			mem_aln2sam(opt, bns, &str, s, aa.n, aa.a, k, m, 0);
 		for (k = 0; k < aa.n; ++k) free(aa.a[k].cigar);
 		free(aa.a);
 	}

--- a/bwamem.c
+++ b/bwamem.c
@@ -932,7 +932,7 @@ void mem_aln2sam(const mem_opt_t *opt, const bntseq_t *bns, kstring_t *str, bseq
 		kputsn("\tMD:Z:", 6, str); kputs((char*)(p->cigar + p->n_cigar), str);
 	}
 	if (m && m->n_cigar) { kputsn("\tMC:Z:", 6, str); add_cigar(opt, m, str, which); }
-    if (m) { kputsn("\tMQ:i:", 6, str); kputw(m->mapq, str); }
+    if (m && opt->flag & MEM_F_MS) { kputsn("\tMQ:i:", 6, str); kputw(m->mapq, str); }
     if (m && opt->flag & MEM_F_MS) { kputsn("\tms:i:", 6, str); kputw(ms, str); }
 	if (p->score >= 0) { kputsn("\tAS:i:", 6, str); kputw(p->score, str); }
 	if (p->sub >= 0) { kputsn("\tXS:i:", 6, str); kputw(p->sub, str); }

--- a/bwamem.h
+++ b/bwamem.h
@@ -48,6 +48,7 @@ typedef struct __smem_i smem_i;
 #define MEM_F_PRIMARY5  0x800
 #define MEM_F_KEEP_SUPP_MAPQ 0x1000
 #define MEM_F_XB        0x2000
+#define MEM_F_MS        0x4000
 
 typedef struct {
 	int a, b;               // match score and mismatch penalty

--- a/bwtindex.c
+++ b/bwtindex.c
@@ -79,7 +79,6 @@ bwt_t *bwt_pac2bwt(const char *fn_pac, int use_is)
 	buf2 = (ubyte_t*)calloc(pac_size, 1);
 	err_fread_noeof(buf2, 1, pac_size, fp);
 	err_fclose(fp);
-	memset(bwt->L2, 0, 5 * 4);
 	buf = (ubyte_t*)calloc(bwt->seq_len + 1, 1);
 	for (i = 0; i < bwt->seq_len; ++i) {
 		buf[i] = buf2[i>>2] >> ((3 - (i&3)) << 1) & 3;

--- a/fastmap.c
+++ b/fastmap.c
@@ -156,7 +156,7 @@ int main_mem(int argc, char *argv[])
 
 	aux.opt = opt = mem_opt_init();
 	memset(&opt0, 0, sizeof(mem_opt_t));
-	while ((c = getopt(argc, argv, "51qpaMCSPVYjuk:c:v:s:r:t:R:A:B:O:E:U:w:L:d:T:Q:D:m:I:N:o:f:W:x:G:h:y:K:X:H:F:")) >= 0) {
+	while ((c = getopt(argc, argv, "351qpaMCSPVYjuk:c:v:s:r:t:R:A:B:O:E:U:w:L:d:T:Q:D:m:I:N:o:f:W:x:G:h:y:K:X:H:F:")) >= 0) {
 		if (c == 'k') opt->min_seed_len = atoi(optarg), opt0.min_seed_len = 1;
 		else if (c == '1') no_mt_io = 1;
 		else if (c == 'x') mode = optarg;
@@ -176,6 +176,7 @@ int main_mem(int argc, char *argv[])
 		else if (c == '5') opt->flag |= MEM_F_PRIMARY5 | MEM_F_KEEP_SUPP_MAPQ; // always apply MEM_F_KEEP_SUPP_MAPQ with -5
 		else if (c == 'q') opt->flag |= MEM_F_KEEP_SUPP_MAPQ;
 		else if (c == 'u') opt->flag |= MEM_F_XB;
+        else if (c == '3') opt->flag |= MEM_F_MS; 
 		else if (c == 'c') opt->max_occ = atoi(optarg), opt0.max_occ = 1;
 		else if (c == 'd') opt->zdrop = atoi(optarg), opt0.zdrop = 1;
 		else if (c == 'v') bwa_verbose = atoi(optarg);
@@ -308,7 +309,8 @@ int main_mem(int argc, char *argv[])
 		fprintf(stderr, "       -C            append FASTA/FASTQ comment to SAM output\n");
 		fprintf(stderr, "       -V            output the reference FASTA header in the XR tag\n");
 		fprintf(stderr, "       -Y            use soft clipping for supplementary alignments\n");
-		fprintf(stderr, "       -M            mark shorter split hits as secondary\n\n");
+		fprintf(stderr, "       -M            mark shorter split hits as secondary\n");
+		fprintf(stderr, "       -3            output 'ms' and 'MQ' tag for samtools markdup usage\n");
 		fprintf(stderr, "       -I FLOAT[,FLOAT[,INT[,INT]]]\n");
 		fprintf(stderr, "                     specify the mean, standard deviation (10%% of the mean if absent), max\n");
 		fprintf(stderr, "                     (4 sigma from the mean if absent) and min of the insert size distribution.\n");


### PR DESCRIPTION
1. function enhancement
add ```-3``` option to ```bwa mem``` to generate the ```ms``` and ```MQ``` tag needed for ```samtools markdup```, so people will not need to do ```sort by names and fix mate and then sort by coordinates``` operations before calling ```samtools markdup``` on an BAM generated by BWA any more.

2. minor redundant code removal
L2 member in the `bwt_t` struct is an array of 5 unsigned integers of type `uint64_t`,  https://github.com/lh3/bwa/blob/master/bwt.h#L50

the initialization of this array in https://github.com/lh3/bwa/blob/master/bwtindex.c#L82 is `memset(bwt->L2, 0, 5 * 4)`, which just only set 20bytes to 0

however, the net results of the function calling this initialization works as it needed. I check the code and found that the struct of bwt_t this array belongs is constructed by `calloc`, which have already set all the elements of the L2 member to 0.https://github.com/lh3/bwa/blob/master/bwtindex.c#L72

so, maybe this redundant and misleading memset code should be removed?
