### PR TITLE
mem_process_seqs: fix redundant memory allocation

### DIFF
--- a/bwamem.c
+++ b/bwamem.c
@@ -1245,7 +1245,7 @@ void mem_process_seqs(const mem_opt_t *opt, const bwt_t *bwt, const bntseq_t *bn
 	w.opt = opt; w.bwt = bwt; w.bns = bns; w.pac = pac;
 	w.seqs = seqs; w.n_processed = n_processed;
 	w.pes = &pes[0];
-	w.aux = malloc(opt->n_threads * sizeof(smem_aux_t));
+	w.aux = malloc(opt->n_threads * sizeof(smem_aux_t*));
 	for (i = 0; i < opt->n_threads; ++i)
 		w.aux[i] = smem_aux_init();
 	kt_for(opt->n_threads, worker1, &w, (opt->flag&MEM_F_PE)? n>>1 : n); // find mapping positions


### PR DESCRIPTION
I think there was an issue of incorrect determining the size of array of pointers using size of the object instead the size of pointer.