### PR TITLE
Use GitHub Actions instead of Travis CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compiler: [gcc, clang]
+
+    steps:
+    - name: Checkout bwa
+      uses: actions/checkout@v2
+
+    - name: Compile with ${{ matrix.compiler }}
+      run:  make CC=${{ matrix.compiler }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: c
-compiler:
-  - gcc
-  - clang
-script: make


### PR DESCRIPTION
An example GitHub Actions workflow that tests compilation with both GCC and Clang, equivalently to the existing Travis setup. Fixes #324.

After removing _.travis.yml_, I'd recommend going to the bwa repository's [Settings :: Webhooks](https://github.com/lh3/bwa/settings/hooks) page and removing travis's hook; and perhaps also logging in to travis-ci.org and disabling repos and accounts there.