### PR TITLE
bugfix: HD line should be printed before SQ

### DIFF
--- a/bwa.c
+++ b/bwa.c
@@ -421,7 +421,14 @@ void bwa_print_sam_hdr(const bntseq_t *bns, const char *hdr_line)
 			if (p == hdr_line || *(p-1) == '\n') ++n_SQ;
 			p += 4;
 		}
+		// print the header line if @HD is in hdr_line
+		if (n_HD > 0) err_printf("%s\n", hdr_line);
 	}
+	// print a default header line if no @HD has been printed
+	if (n_HD == 0) {
+		err_printf("@HD\tVN:1.5\tSO:unsorted\tGO:query\n");
+	}
+	// print the @SQ lines right after the @HD line
 	if (n_SQ == 0) {
 		for (i = 0; i < bns->n_seqs; ++i) {
 			err_printf("@SQ\tSN:%s\tLN:%d", bns->anns[i].name, bns->anns[i].len);
@@ -430,10 +437,8 @@ void bwa_print_sam_hdr(const bntseq_t *bns, const char *hdr_line)
 		}
 	} else if (n_SQ != bns->n_seqs && bwa_verbose >= 2)
 		fprintf(stderr, "[W::%s] %d @SQ lines provided with -H; %d sequences in the index. Continue anyway.\n", __func__, n_SQ, bns->n_seqs);
-	if (n_HD == 0) {
-		err_printf("@HD\tVN:1.5\tSO:unsorted\tGO:query\n");
-	}
-	if (hdr_line) err_printf("%s\n", hdr_line);
+	// print the header line if header line is defined and is not a @HD (e.g. @CO); do this after the @SQ lines. 
+	if (hdr_line && n_HD == 0) err_printf("%s\n", hdr_line);
 	if (bwa_pg) err_printf("%s\n", bwa_pg);
 }
 


### PR DESCRIPTION
Fixes a long standing bug, but made more apparent in https://github.com/lh3/bwa/pull/336. Thank @jmarshall for pointing this out.

I tested this by on my local machine three ways.

1. Not specifying `-H`, so the default header line should be emitted at the start of the SAM:
```console
./bwa mem phix.fasta phix.fastq 
[M::bwa_idx_load_from_disk] read 0 ALT contigs
@HD VN:1.5  SO:unsorted GO:query
@SQ SN:gi|9626372|ref|NC_001422.1|  LN:5386
...
```

2. Specifying `-H` with `@HD`, so the user provided header line should be emitted at the start of the SAM:
```console
./bwa mem -H '@HD  VN:1.4  SO:unsorted     GO:query'  phix.fasta phix.fastq 
[M::bwa_idx_load_from_disk] read 0 ALT contigs
@HD VN:1.4  SO:unsorted GO:query
@SQ SN:gi|9626372|ref|NC_001422.1|  LN:5386
...
```

3. Specifying `-H` with `@CO`, so the default header line should be emitted at the start of the SAM, while the CO line should be after the SQ lines.
```console
./bwa mem -H '@CO  ID:id' phix.fasta phix.fastq 
[M::bwa_idx_load_from_disk] read 0 ALT contigs
@HD	VN:1.5	SO:unsorted	GO:query
@SQ	SN:gi|9626372|ref|NC_001422.1|	LN:5386
@CO	ID:id
```