### PR TITLE
Avoid conflicting with HTSlib's kstring.c functions

### DIFF
--- a/kstring.c
+++ b/kstring.c
@@ -6,21 +6,19 @@
 #  include "malloc_wrap.h"
 #endif
 
-int ksprintf(kstring_t *s, const char *fmt, ...)
+int bwa_kvsprintf(kstring_t *s, const char *fmt, va_list ap)
 {
-	va_list ap;
+	va_list ap2;
 	int l;
-	va_start(ap, fmt);
+	va_copy(ap2, ap);
 	l = vsnprintf(s->s + s->l, s->m - s->l, fmt, ap);
-	va_end(ap);
 	if (l + 1 > s->m - s->l) {
 		s->m = s->l + l + 2;
 		kroundup32(s->m);
 		s->s = (char*)realloc(s->s, s->m);
-		va_start(ap, fmt);
-		l = vsnprintf(s->s + s->l, s->m - s->l, fmt, ap);
+		l = vsnprintf(s->s + s->l, s->m - s->l, fmt, ap2);
 	}
-	va_end(ap);
+	va_end(ap2);
 	s->l += l;
 	return l;
 }

--- a/kstring.h
+++ b/kstring.h
@@ -3,6 +3,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <stdarg.h>
 
 #ifdef USE_MALLOC_WRAPPERS
 #  include "malloc_wrap.h"
@@ -110,6 +111,21 @@ static inline int kputl(long c, kstring_t *s)
 	return 0;
 }
 
-int ksprintf(kstring_t *s, const char *fmt, ...);
+int bwa_kvsprintf(kstring_t *s, const char *fmt, va_list ap);
+
+static inline int ksprintf(kstring_t *s, const char *fmt, ...)
+{
+	va_list ap;
+	int l;
+	va_start(ap, fmt);
+	l = bwa_kvsprintf(s, fmt, ap);
+	va_end(ap);
+	return l;
+}
+
+static inline int kvsprintf(kstring_t *s, const char *fmt, va_list ap)
+{
+	return bwa_kvsprintf(s, fmt, ap);
+}
 
 #endif


### PR DESCRIPTION
Some people's programs use both HTSlib and libbwa.a — see e.g. samtools/htslib#693. Unfortunately one function — `ksprintf` — is defined in both libraries, leading to linker errors.

This happens for `ksprintf` only, because all the other functions in bwa's _kstring.h_ are declared as `static inline`.

This PR makes `ksprintf()` static inline in _kstring.h_, so that it (like the other _bwa/kstring.h_ functions) won't conflict with similar HTSlib functions. Instead implement it and a new `kvsprintf()` in terms of a new `bwa_kvsprintf()` function. Fixes samtools/htslib#693.