### PR TITLE
add condition to BSW in case of reversing

### DIFF
--- a/ksw.c
+++ b/ksw.c
@@ -416,6 +416,7 @@ int ksw_extend2(int qlen, const uint8_t *query, int tlen, const uint8_t *target,
 		if (beg < i - w) beg = i - w;
 		if (end > i + w + 1) end = i + w + 1;
 		if (end > qlen) end = qlen;
+		if (beg >= end) break; // in case of reversing beg and end
 		// compute the first column
 		if (beg == 0) {
 			h1 = h0 - (o_del + e_del * (i + 1));


### PR DESCRIPTION
add condition to BSW in case of reversing
: It calculated h from beg to end.
 Because of the applying band, sometimes beg can grow bigger than end.
 Then skip i and run i+1 with the e-h value of i-1, not i's. It could cause misalignment.
 So, I added break condition.

example)
w = 81, qlen = 72
if i = 165,   i-w = 84   > beg = 84
end = 72
