### PR TITLE
add break condition to making cigar string

### DIFF
--- a/ksw.c
+++ b/ksw.c
@@ -590,7 +590,11 @@ int ksw_global2(int qlen, const uint8_t *query, int tlen, const uint8_t *target,
 		uint32_t *cigar = 0, tmp;
 		i = tlen - 1; k = (i + w + 1 < qlen? i + w + 1 : qlen) - 1; // (i,k) points to the last cell
 		while (i >= 0 && k >= 0) {
-			which = z[(long)i * n_col + (k - (i > w? i - w : 0))] >> (which<<1) & 3;
+			int j_beg = i > w? i - w : 0;
+			int j_end = i + w + 1 < qlen? i + w + 1 : qlen;
+			j = (k - j_beg);
+			if (j < j_beg || j >= j_end)	break;
+			which = z[(long)i * n_col + j] >> (which<<1) & 3;
 			if (which == 0)      cigar = push_cigar(&n_cigar, &m_cigar, cigar, 0, 1), --i, --k;
 			else if (which == 1) cigar = push_cigar(&n_cigar, &m_cigar, cigar, 2, 1), --i;
 			else                 cigar = push_cigar(&n_cigar, &m_cigar, cigar, 1, 1), --k;

--- a/ksw.c
+++ b/ksw.c
@@ -593,7 +593,7 @@ int ksw_global2(int qlen, const uint8_t *query, int tlen, const uint8_t *target,
 			int j_beg = i > w? i - w : 0;
 			int j_end = i + w + 1 < qlen? i + w + 1 : qlen;
 			j = (k - j_beg);
-			if (j < j_beg || j >= j_end)	break;
+			if (j >= (j_end-j_beg))	break;
 			which = z[(long)i * n_col + j] >> (which<<1) & 3;
 			if (which == 0)      cigar = push_cigar(&n_cigar, &m_cigar, cigar, 0, 1), --i, --k;
 			else if (which == 1) cigar = push_cigar(&n_cigar, &m_cigar, cigar, 2, 1), --i;


### PR DESCRIPTION
add break condition to making cigar string
: ksw_global2 calculate z value from beg to end.
Accessing an uncalculated area has no choice but to read unknown data. ( Since z is not initialized because it is provided by malloc)
Then, it cause making wrong cigar. 
