### PR TITLE
Added -fPIC as compile flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC=			gcc
 #CC=			clang --analyze
-CFLAGS=		-g -Wall -Wno-unused-function -O2
+CFLAGS=		-g -Wall -Wno-unused-function -O2 -fPIC
 WRAP_MALLOC=-DUSE_MALLOC_WRAPPERS
 AR=			ar
 DFLAGS=		-DHAVE_PTHREAD $(WRAP_MALLOC)


### PR DESCRIPTION
Can we consider to add this flag to the Makefile, it enables users that have bwa as their dependency to create shared objects. 
From the manual page       
-fPIC
         If supported for the target machine, emit position-independent code, suitable for dynamic linking and avoiding any limit on
         the size of the global offset table.  This option makes a difference on AArch64, m68k, PowerPC and SPARC.
         Position-independent code requires special support, and therefore works only on certain machines.
         When this flag is set, the macros "__pic__" and "__PIC__" are defined to 2.