### PR TITLE
Update rle.h

### DIFF
--- a/rle.h
+++ b/rle.h
@@ -30,7 +30,7 @@ extern "C" {
  *** 43+3 codec ***
  ******************/
 
-extern const uint8_t rle_auxtab[8];
+//extern const uint8_t rle_auxtab[8];
 
 #define RLE_MIN_SPACE 18
 #define rle_nptr(block) ((uint16_t*)(block))


### PR DESCRIPTION
Encountered the following error (ubuntu 20.04, gcc 11.3.0-1ubuntu1~22.04). Supposedly this error only occurs on [some versions of gcc](https://github.com/lh3/bwa/issues/275)?

gcc -g -Wall -Wno-unused-function -O2 -DHAVE_PTHREAD -DUSE_MALLOC_WRAPPERS bwashm.o bwase.o bwaseqio.o bwtgap.o bwtaln.o bamlite.o bwape.o kopen.o pemerge.o maxk.o bwtsw2_core.o bwtsw2_main.o bwtsw2_aux.o bwt_lite.o bwtsw2_chain.o fastmap.o bwtsw2_pair.o main.o -o bwa -L. -lbwa -lm -lz -lpthread -lrt
/usr/bin/ld: ./libbwa.a(rope.o):/utils/svaba/SeqLib/bwa/rle.h:33: multiple definition of `rle_auxtab'; ./libbwa.a(bwtindex.o):/utils/svaba/SeqLib/bwa/rle.h:33: first defined here
/usr/bin/ld: ./libbwa.a(rle.o):/utils/svaba/SeqLib/bwa/rle.h:33: multiple definition of `rle_auxtab'; ./libbwa.a(bwtindex.o):/utils/svaba/SeqLib/bwa/rle.h:33: first defined here
collect2: error: ld returned 1 exit status
make: *** [Makefile:33: bwa] Error 1

commenting out the offending line appears to solve the problem.