### PR TITLE
Fixed a bug on shm existence checking when there are indice more than two.

### DIFF
--- a/bwashm.c
+++ b/bwashm.c
@@ -132,7 +132,7 @@ int bwa_shm_test(const char *hint)
 	cnt = (uint16_t*)shm;
 	for (i = 0, p = shm + 4; i < cnt[0]; ++i) {
 		if (strcmp(p + 8, name) == 0) return 1;
-		p += strlen(p) + 9;
+		p += strlen(p + 8) + 9;
 	}
 	return 0;
 }


### PR DESCRIPTION
There was a bug in offset handling while traversing over indice info such as  memory length and index name.